### PR TITLE
Add all classic S2 cheats and a few more

### DIFF
--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -306,6 +306,12 @@ bool VideoSDL2::MessageLoop()
                         // Die 12 F-Tasten
                         if(ev.key.keysym.sym >= SDLK_F1 && ev.key.keysym.sym <= SDLK_F12)
                             ke.kt = static_cast<KeyType>(rttr::enum_cast(KeyType::F1) + ev.key.keysym.sym - SDLK_F1);
+
+                        if((SDL_GetModState() & KMOD_ALT) && isdigit(ev.key.keysym.sym))
+                        {
+                            ke.kt = KeyType::Char;
+                            ke.c = ev.key.keysym.sym;
+                        }
                     }
                     break;
                     case SDLK_RETURN: ke.kt = KeyType::Return; break;

--- a/libs/s25main/CheatCommandTracker.cpp
+++ b/libs/s25main/CheatCommandTracker.cpp
@@ -1,0 +1,44 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "CheatCommandTracker.h"
+#include "Cheats.h"
+#include "driver/KeyEvent.h"
+
+void CheatCommandTracker::trackKeyEvent(const KeyEvent& ke)
+{
+    switch(ke.kt)
+    {
+        case KeyType::F10: return cheats_.toggleHumanAIPlayer();
+        default:;
+    }
+
+    static std::string winterCheat = "winter";
+    switch(ke.c)
+    {
+        case 'w':
+        case 'i':
+        case 'n':
+        case 't':
+        case 'e':
+        case 'r':
+            curCheatTxt_ += char(ke.c);
+            if(winterCheat.find(curCheatTxt_) == 0)
+            {
+                if(curCheatTxt_ == winterCheat)
+                {
+                    cheats_.toggleCheatMode();
+                    curCheatTxt_.clear();
+                }
+            } else
+                curCheatTxt_.clear();
+            break;
+    }
+}
+
+void CheatCommandTracker::trackChatCommand(const std::string& cmd)
+{
+    if(cmd == "apocalypsis")
+        cheats_.armageddon();
+}

--- a/libs/s25main/CheatCommandTracker.cpp
+++ b/libs/s25main/CheatCommandTracker.cpp
@@ -38,6 +38,16 @@ bool CheatCommandTracker::trackSpecialKeyEvent(const KeyEvent& ke)
     if(ke.kt == KeyType::Char)
         return false;
 
+    if(ke.ctrl && ke.shift)
+    {
+        if(ke.kt >= KeyType::F1 && ke.kt <= KeyType::F8)
+            cheats_.destroyBuildings({static_cast<unsigned>(ke.kt) - static_cast<unsigned>(KeyType::F1)});
+        else if(ke.kt == KeyType::F9)
+            cheats_.destroyAllAIBuildings();
+
+        return true;
+    }
+
     switch(ke.kt)
     {
         case KeyType::F7:

--- a/libs/s25main/CheatCommandTracker.cpp
+++ b/libs/s25main/CheatCommandTracker.cpp
@@ -18,7 +18,7 @@ CheatCommandTracker::CheatCommandTracker(Cheats& cheats) : cheats_(cheats), last
 
 void CheatCommandTracker::trackKeyEvent(const KeyEvent& ke)
 {
-    if(trackSpecialKeyEvent(ke))
+    if(trackSpecialKeyEvent(ke) || trackSpeedKeyEvent(ke))
     {
         lastChars_.clear();
         return;
@@ -63,6 +63,17 @@ bool CheatCommandTracker::trackSpecialKeyEvent(const KeyEvent& ke)
     }
 
     return true;
+}
+
+bool CheatCommandTracker::trackSpeedKeyEvent(const KeyEvent& ke)
+{
+    const char c = ke.c;
+    if(ke.alt && c >= '1' && c <= '6')
+    {
+        cheats_.setGameSpeed(c - '1');
+        return true;
+    }
+    return false;
 }
 
 bool CheatCommandTracker::trackCharKeyEvent(const KeyEvent& ke)

--- a/libs/s25main/CheatCommandTracker.cpp
+++ b/libs/s25main/CheatCommandTracker.cpp
@@ -40,7 +40,14 @@ bool CheatCommandTracker::trackSpecialKeyEvent(const KeyEvent& ke)
 
     switch(ke.kt)
     {
-        case KeyType::F7: cheats_.toggleAllVisible(); break;
+        case KeyType::F7:
+        {
+            if(ke.alt)
+                cheats_.toggleResourceRevealMode();
+            else
+                cheats_.toggleAllVisible();
+        }
+        break;
         case KeyType::F10: cheats_.toggleHumanAIPlayer(); break;
         default: break;
     }

--- a/libs/s25main/CheatCommandTracker.cpp
+++ b/libs/s25main/CheatCommandTracker.cpp
@@ -40,6 +40,7 @@ bool CheatCommandTracker::trackSpecialKeyEvent(const KeyEvent& ke)
 
     switch(ke.kt)
     {
+        case KeyType::F7: cheats_.toggleAllVisible(); break;
         case KeyType::F10: cheats_.toggleHumanAIPlayer(); break;
         default: break;
     }

--- a/libs/s25main/CheatCommandTracker.h
+++ b/libs/s25main/CheatCommandTracker.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <boost/circular_buffer.hpp>
 #include <string>
 
 class Cheats;
@@ -12,12 +13,15 @@ struct KeyEvent;
 class CheatCommandTracker
 {
 public:
-    CheatCommandTracker(Cheats& cheats) : cheats_(cheats) {}
+    CheatCommandTracker(Cheats& cheats);
 
     void trackKeyEvent(const KeyEvent& ke);
     void trackChatCommand(const std::string& cmd);
 
 private:
+    bool trackSpecialKeyEvent(const KeyEvent& ke);
+    bool trackCharKeyEvent(const KeyEvent& ke);
+
     Cheats& cheats_;
-    std::string curCheatTxt_;
+    boost::circular_buffer<char> lastChars_;
 };

--- a/libs/s25main/CheatCommandTracker.h
+++ b/libs/s25main/CheatCommandTracker.h
@@ -1,0 +1,23 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string>
+
+class Cheats;
+struct KeyEvent;
+
+class CheatCommandTracker
+{
+public:
+    CheatCommandTracker(Cheats& cheats) : cheats_(cheats) {}
+
+    void trackKeyEvent(const KeyEvent& ke);
+    void trackChatCommand(const std::string& cmd);
+
+private:
+    Cheats& cheats_;
+    std::string curCheatTxt_;
+};

--- a/libs/s25main/CheatCommandTracker.h
+++ b/libs/s25main/CheatCommandTracker.h
@@ -15,12 +15,41 @@ class CheatCommandTracker
 public:
     CheatCommandTracker(Cheats& cheats);
 
+    /** Tracks keyboard events related to cheats and triggers the actual cheats.
+     * Calls related private methods of this class in order but returns at the first success (return true).
+     *
+     * @param ke - The keyboard event encountered.
+     */
     void trackKeyEvent(const KeyEvent& ke);
+
+    /** Tracks chat commands related to cheats and triggers the actual cheats.
+     *
+     * @param cmd - The chat command to track.
+     */
     void trackChatCommand(const std::string& cmd);
 
 private:
+    /** Tracks keyboard events related to cheats and triggers the actual cheats, but only tracks events of type
+     * different than KeyType::Char (e.g. F-keys).
+     *
+     * @param ke - The keyboard event encountered.
+     * @return true if keyboard event was NOT of type KeyType::Char, false otherwise
+     */
     bool trackSpecialKeyEvent(const KeyEvent& ke);
+
+    /** Tracks keyboard events related to game speed cheats (ALT+1..ALT+6) and triggers the actual cheats.
+     *
+     * @param ke - The keyboard event encountered.
+     * @return true if keyboard event was related to game speed cheats, false otherwise
+     */
     bool trackSpeedKeyEvent(const KeyEvent& ke);
+
+    /** Tracks keyboard events related to cheats and triggers the actual cheats, but only tracks events of type
+     * KeyType::Char (e.g. enabling cheat mode by typing "winter").
+     *
+     * @param ke - The keyboard event encountered.
+     * @return always true
+     */
     bool trackCharKeyEvent(const KeyEvent& ke);
 
     Cheats& cheats_;

--- a/libs/s25main/CheatCommandTracker.h
+++ b/libs/s25main/CheatCommandTracker.h
@@ -20,6 +20,7 @@ public:
 
 private:
     bool trackSpecialKeyEvent(const KeyEvent& ke);
+    bool trackSpeedKeyEvent(const KeyEvent& ke);
     bool trackCharKeyEvent(const KeyEvent& ke);
 
     Cheats& cheats_;

--- a/libs/s25main/Cheats.cpp
+++ b/libs/s25main/Cheats.cpp
@@ -1,0 +1,53 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "Cheats.h"
+#include "driver/KeyEvent.h"
+#include "network/GameClient.h"
+
+void Cheats::trackKeyEvent(const KeyEvent& ke)
+{
+    switch(ke.kt)
+    {
+        case KeyType::F10:
+        {
+#ifdef NDEBUG
+            const bool allowHumanAI = isCheatModeOn_;
+#else
+            const bool allowHumanAI = true;
+#endif // !NDEBUG
+            if(GAMECLIENT.GetState() == ClientState::Game && allowHumanAI && !GAMECLIENT.IsReplayModeOn())
+                GAMECLIENT.ToggleHumanAIPlayer(AI::Info(AI::Type::Default, AI::Level::Easy));
+        }
+        default:;
+    }
+
+    static std::string winterCheat = "winter";
+    switch(ke.c)
+    {
+        case 'w':
+        case 'i':
+        case 'n':
+        case 't':
+        case 'e':
+        case 'r':
+            curCheatTxt_ += char(ke.c);
+            if(winterCheat.find(curCheatTxt_) == 0)
+            {
+                if(curCheatTxt_ == winterCheat)
+                {
+                    isCheatModeOn_ = !isCheatModeOn_;
+                    curCheatTxt_.clear();
+                }
+            } else
+                curCheatTxt_.clear();
+            break;
+    }
+}
+
+void Cheats::trackChatCommand(const std::string& cmd)
+{
+    if(cmd == "apocalypsis")
+        GAMECLIENT.CheatArmageddon();
+}

--- a/libs/s25main/Cheats.cpp
+++ b/libs/s25main/Cheats.cpp
@@ -37,13 +37,13 @@ void Cheats::toggleCheatMode()
 
 void Cheats::toggleHumanAIPlayer()
 {
-#ifdef NDEBUG
-    const bool allowHumanAI = isCheatModeOn_;
-#else
-    const bool allowHumanAI = true;
-#endif // !NDEBUG
-    if(GAMECLIENT.GetState() == ClientState::Game && allowHumanAI && !GAMECLIENT.IsReplayModeOn())
-        GAMECLIENT.ToggleHumanAIPlayer(AI::Info(AI::Type::Default, AI::Level::Easy));
+    if(!isCheatModeOn())
+        return;
+
+    if(GAMECLIENT.IsReplayModeOn())
+        return;
+
+    GAMECLIENT.ToggleHumanAIPlayer(AI::Info{AI::Type::Default, AI::Level::Easy});
 }
 
 void Cheats::armageddon()

--- a/libs/s25main/Cheats.cpp
+++ b/libs/s25main/Cheats.cpp
@@ -5,23 +5,33 @@
 #include "Cheats.h"
 #include "CheatCommandTracker.h"
 #include "network/GameClient.h"
+#include "world/GameWorldBase.h"
 
-Cheats::Cheats() : cheatCmdTracker_(std::make_unique<CheatCommandTracker>(*this)) {}
+Cheats::Cheats(GameWorldBase& world) : cheatCmdTracker_(std::make_unique<CheatCommandTracker>(*this)), world_(world) {}
 
 Cheats::~Cheats() = default;
 
 void Cheats::trackKeyEvent(const KeyEvent& ke)
 {
+    if(!canCheatModeBeOn())
+        return;
+
     cheatCmdTracker_->trackKeyEvent(ke);
 }
 
 void Cheats::trackChatCommand(const std::string& cmd)
 {
+    if(!canCheatModeBeOn())
+        return;
+
     cheatCmdTracker_->trackChatCommand(cmd);
 }
 
 void Cheats::toggleCheatMode()
 {
+    if(!canCheatModeBeOn())
+        return;
+
     isCheatModeOn_ = !isCheatModeOn_;
 }
 
@@ -39,4 +49,9 @@ void Cheats::toggleHumanAIPlayer()
 void Cheats::armageddon()
 {
     GAMECLIENT.CheatArmageddon();
+}
+
+bool Cheats::canCheatModeBeOn() const
+{
+    return world_.IsSinglePlayer();
 }

--- a/libs/s25main/Cheats.cpp
+++ b/libs/s25main/Cheats.cpp
@@ -48,6 +48,9 @@ void Cheats::toggleHumanAIPlayer()
 
 void Cheats::armageddon()
 {
+    if(!isCheatModeOn())
+        return;
+
     GAMECLIENT.CheatArmageddon();
 }
 

--- a/libs/s25main/Cheats.cpp
+++ b/libs/s25main/Cheats.cpp
@@ -3,51 +3,40 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "Cheats.h"
-#include "driver/KeyEvent.h"
+#include "CheatCommandTracker.h"
 #include "network/GameClient.h"
+
+Cheats::Cheats() : cheatCmdTracker_(std::make_unique<CheatCommandTracker>(*this)) {}
+
+Cheats::~Cheats() = default;
 
 void Cheats::trackKeyEvent(const KeyEvent& ke)
 {
-    switch(ke.kt)
-    {
-        case KeyType::F10:
-        {
-#ifdef NDEBUG
-            const bool allowHumanAI = isCheatModeOn_;
-#else
-            const bool allowHumanAI = true;
-#endif // !NDEBUG
-            if(GAMECLIENT.GetState() == ClientState::Game && allowHumanAI && !GAMECLIENT.IsReplayModeOn())
-                GAMECLIENT.ToggleHumanAIPlayer(AI::Info(AI::Type::Default, AI::Level::Easy));
-        }
-        default:;
-    }
-
-    static std::string winterCheat = "winter";
-    switch(ke.c)
-    {
-        case 'w':
-        case 'i':
-        case 'n':
-        case 't':
-        case 'e':
-        case 'r':
-            curCheatTxt_ += char(ke.c);
-            if(winterCheat.find(curCheatTxt_) == 0)
-            {
-                if(curCheatTxt_ == winterCheat)
-                {
-                    isCheatModeOn_ = !isCheatModeOn_;
-                    curCheatTxt_.clear();
-                }
-            } else
-                curCheatTxt_.clear();
-            break;
-    }
+    cheatCmdTracker_->trackKeyEvent(ke);
 }
 
 void Cheats::trackChatCommand(const std::string& cmd)
 {
-    if(cmd == "apocalypsis")
-        GAMECLIENT.CheatArmageddon();
+    cheatCmdTracker_->trackChatCommand(cmd);
+}
+
+void Cheats::toggleCheatMode()
+{
+    isCheatModeOn_ = !isCheatModeOn_;
+}
+
+void Cheats::toggleHumanAIPlayer()
+{
+#ifdef NDEBUG
+    const bool allowHumanAI = isCheatModeOn_;
+#else
+    const bool allowHumanAI = true;
+#endif // !NDEBUG
+    if(GAMECLIENT.GetState() == ClientState::Game && allowHumanAI && !GAMECLIENT.IsReplayModeOn())
+        GAMECLIENT.ToggleHumanAIPlayer(AI::Info(AI::Type::Default, AI::Level::Easy));
+}
+
+void Cheats::armageddon()
+{
+    GAMECLIENT.CheatArmageddon();
 }

--- a/libs/s25main/Cheats.cpp
+++ b/libs/s25main/Cheats.cpp
@@ -4,6 +4,7 @@
 
 #include "Cheats.h"
 #include "CheatCommandTracker.h"
+#include "GameInterface.h"
 #include "network/GameClient.h"
 #include "world/GameWorldBase.h"
 
@@ -33,6 +34,20 @@ void Cheats::toggleCheatMode()
         return;
 
     isCheatModeOn_ = !isCheatModeOn_;
+}
+
+void Cheats::toggleAllVisible()
+{
+    // This is actually the behavior of the original game.
+    // If you enabled cheats, revealed the map and disabled cheats you would be unable to unreveal the map.
+    if(!isCheatModeOn())
+        return;
+
+    isAllVisible_ = !isAllVisible_;
+
+    // The minimap in the original game is not updated immediately, but here this would cause complications.
+    if(GameInterface* gi = world_.GetGameInterface())
+        gi->GI_UpdateMapVisibility();
 }
 
 void Cheats::toggleHumanAIPlayer()

--- a/libs/s25main/Cheats.cpp
+++ b/libs/s25main/Cheats.cpp
@@ -6,6 +6,7 @@
 #include "CheatCommandTracker.h"
 #include "GameInterface.h"
 #include "GamePlayer.h"
+#include "RttrForeachPt.h"
 #include "factories/BuildingFactory.h"
 #include "network/GameClient.h"
 #include "world/GameWorldBase.h"
@@ -109,6 +110,28 @@ void Cheats::toggleResourceRevealMode()
         case ResourceRevealMode::Fish: resourceRevealMode_ = ResourceRevealMode::Water; break;
         default: resourceRevealMode_ = ResourceRevealMode::Nothing; break;
     }
+}
+
+void Cheats::destroyBuildings(const PlayerIDSet& playerIds)
+{
+    if(!isCheatModeOn())
+        return;
+
+    RTTR_FOREACH_PT(MapPoint, world_.GetSize())
+        if(world_.GetNO(pt)->GetType() == NodalObjectType::Building && playerIds.count(world_.GetNode(pt).owner - 1))
+            world_.DestroyNO(pt);
+}
+
+void Cheats::destroyAllAIBuildings()
+{
+    if(!isCheatModeOn())
+        return;
+
+    PlayerIDSet ais;
+    for(auto i = 0u; i < world_.GetNumPlayers(); ++i)
+        if(!world_.GetPlayer(i).isHuman())
+            ais.insert(i);
+    destroyBuildings(ais);
 }
 
 bool Cheats::canCheatModeBeOn() const

--- a/libs/s25main/Cheats.cpp
+++ b/libs/s25main/Cheats.cpp
@@ -77,6 +77,16 @@ void Cheats::placeCheatBuilding(const MapPoint& mp, const GamePlayer& player)
                                     player.IsHQTent());
 }
 
+void Cheats::setGameSpeed(uint8_t speedIndex)
+{
+    if(!isCheatModeOn())
+        return;
+
+    constexpr auto gfLengthInMs = 50;
+    GAMECLIENT.SetGFLengthReq(FramesInfo::milliseconds32_t{gfLengthInMs >> speedIndex});
+    // 50 -> 25 -> 12 -> 6 -> 3 -> 1
+}
+
 void Cheats::toggleHumanAIPlayer()
 {
     if(!isCheatModeOn())

--- a/libs/s25main/Cheats.cpp
+++ b/libs/s25main/Cheats.cpp
@@ -95,6 +95,22 @@ void Cheats::armageddon()
     GAMECLIENT.CheatArmageddon();
 }
 
+Cheats::ResourceRevealMode Cheats::getResourceRevealMode() const
+{
+    return isCheatModeOn() ? resourceRevealMode_ : ResourceRevealMode::Nothing;
+}
+
+void Cheats::toggleResourceRevealMode()
+{
+    switch(resourceRevealMode_)
+    {
+        case ResourceRevealMode::Nothing: resourceRevealMode_ = ResourceRevealMode::Ores; break;
+        case ResourceRevealMode::Ores: resourceRevealMode_ = ResourceRevealMode::Fish; break;
+        case ResourceRevealMode::Fish: resourceRevealMode_ = ResourceRevealMode::Water; break;
+        default: resourceRevealMode_ = ResourceRevealMode::Nothing; break;
+    }
+}
+
 bool Cheats::canCheatModeBeOn() const
 {
     return world_.IsSinglePlayer();

--- a/libs/s25main/Cheats.h
+++ b/libs/s25main/Cheats.h
@@ -1,0 +1,22 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string>
+
+struct KeyEvent;
+
+class Cheats
+{
+public:
+    bool isCheatModeOn() const { return isCheatModeOn_; }
+
+    void trackKeyEvent(const KeyEvent& ke);
+    void trackChatCommand(const std::string& cmd);
+
+private:
+    bool isCheatModeOn_ = false;
+    std::string curCheatTxt_;
+};

--- a/libs/s25main/Cheats.h
+++ b/libs/s25main/Cheats.h
@@ -4,19 +4,28 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
+class CheatCommandTracker;
 struct KeyEvent;
 
 class Cheats
 {
 public:
-    bool isCheatModeOn() const { return isCheatModeOn_; }
+    Cheats();
+    ~Cheats(); // = default - for unique_ptr
 
     void trackKeyEvent(const KeyEvent& ke);
     void trackChatCommand(const std::string& cmd);
 
+    void toggleCheatMode();
+    bool isCheatModeOn() const { return isCheatModeOn_; }
+
+    void toggleHumanAIPlayer();
+    void armageddon();
+
 private:
+    std::unique_ptr<CheatCommandTracker> cheatCmdTracker_;
     bool isCheatModeOn_ = false;
-    std::string curCheatTxt_;
 };

--- a/libs/s25main/Cheats.h
+++ b/libs/s25main/Cheats.h
@@ -8,12 +8,13 @@
 #include <string>
 
 class CheatCommandTracker;
+class GameWorldBase;
 struct KeyEvent;
 
 class Cheats
 {
 public:
-    Cheats();
+    Cheats(GameWorldBase& world);
     ~Cheats(); // = default - for unique_ptr
 
     void trackKeyEvent(const KeyEvent& ke);
@@ -26,6 +27,9 @@ public:
     void armageddon();
 
 private:
+    bool canCheatModeBeOn() const;
+
     std::unique_ptr<CheatCommandTracker> cheatCmdTracker_;
     bool isCheatModeOn_ = false;
+    GameWorldBase& world_;
 };

--- a/libs/s25main/Cheats.h
+++ b/libs/s25main/Cheats.h
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include "gameTypes/MapCoordinates.h"
 #include <memory>
 #include <string>
 
 class CheatCommandTracker;
+class GamePlayer;
 class GameWorldBase;
 struct KeyEvent;
 
@@ -26,6 +28,9 @@ public:
     // Classic S2 cheats
     void toggleAllVisible();
     bool isAllVisible() const { return isAllVisible_; }
+
+    bool canPlaceCheatBuilding(const MapPoint& mp) const;
+    void placeCheatBuilding(const MapPoint& mp, const GamePlayer& player);
 
     // RTTR cheats
     void toggleHumanAIPlayer();

--- a/libs/s25main/Cheats.h
+++ b/libs/s25main/Cheats.h
@@ -23,6 +23,11 @@ public:
     void toggleCheatMode();
     bool isCheatModeOn() const { return isCheatModeOn_; }
 
+    // Classic S2 cheats
+    void toggleAllVisible();
+    bool isAllVisible() const { return isAllVisible_; }
+
+    // RTTR cheats
     void toggleHumanAIPlayer();
     void armageddon();
 
@@ -31,5 +36,6 @@ private:
 
     std::unique_ptr<CheatCommandTracker> cheatCmdTracker_;
     bool isCheatModeOn_ = false;
+    bool isAllVisible_ = false;
     GameWorldBase& world_;
 };

--- a/libs/s25main/Cheats.h
+++ b/libs/s25main/Cheats.h
@@ -33,6 +33,8 @@ public:
     bool canPlaceCheatBuilding(const MapPoint& mp) const;
     void placeCheatBuilding(const MapPoint& mp, const GamePlayer& player);
 
+    void setGameSpeed(uint8_t speedIndex);
+
     // RTTR cheats
     void toggleHumanAIPlayer();
 

--- a/libs/s25main/Cheats.h
+++ b/libs/s25main/Cheats.h
@@ -20,22 +20,71 @@ public:
     Cheats(GameWorldBase& world);
     ~Cheats(); // = default - for unique_ptr
 
+    /** In single player games, tracks keyboard events related to cheats.
+     * Delegates this responsibility to CheatCommandTracker, which triggers the actual cheats.
+     * In multiplayer games, does nothing. No cheats can be triggered in multiplayer.
+     *
+     * @param ke - The keyboard event encountered.
+     */
     void trackKeyEvent(const KeyEvent& ke);
+
+    /** In single player games, tracks chat commands related to cheats.
+     * Delegates this responsibility to CheatCommandTracker, which triggers the actual cheats.
+     * In multiplayer games, does nothing. No cheats can be triggered in multiplayer.
+     *
+     * @param cmd - The chat command to track.
+     */
     void trackChatCommand(const std::string& cmd);
 
+    /** Toggles cheat mode on and off.
+     * Cheat mode needs to be on for any cheats to trigger.
+     */
     void toggleCheatMode();
+    /** Used by clients to check if cheat mode is on (e.g. to draw special sprites or enable or all buildings).
+     * Cheat mode needs to be on for any cheats to trigger.
+     *
+     * @return true if cheat mode is on, false otherwise
+     */
     bool isCheatModeOn() const { return isCheatModeOn_; }
 
     // Classic S2 cheats
+
+    /** The classic F7 cheat.
+     * Does not modify game state, merely tricks clients into revealing the whole map.
+     * In the background, visibility is tracked as expected, i.e. if you reveal the map, send a scout and unreveal the
+     * map, you will see what was scouted.
+     */
     void toggleAllVisible();
     bool isAllVisible() const { return isAllVisible_; }
 
+    /** The classic build headquarters cheat.
+     * This function is used to check if the cheat building can be placed at the chosen point when opening the activity
+     * window.
+     *
+     * @param mp - The map point where the user clicked to open the activity window.
+     * @return true if the building can be placed, false otherwise
+     */
     bool canPlaceCheatBuilding(const MapPoint& mp) const;
+    /** The classic build headquarters cheat.
+     * This function is used to place the cheat building at the chosen point.
+     * The building is immediately fully built, there is no need for a building site.
+     *
+     * @param mp - The map point at which to place the building.
+     * @param player - The player to whom the building should belong.
+     */
     void placeCheatBuilding(const MapPoint& mp, const GamePlayer& player);
 
+    /** The classic ALT+1 through ALT+6 cheat which changes the game speed.
+     *
+     * @param speedIndex - 0 is normal, 1 is faster, 2 is even faster, etc.
+     */
     void setGameSpeed(uint8_t speedIndex);
 
     // RTTR cheats
+
+    /** Shares control of the (human) user's country with the AI. Both the user and the AI retain full control of the
+     * country, so the user can observe what the AI does or "cooperate" with it.
+     */
     void toggleHumanAIPlayer();
 
     void armageddon();
@@ -47,14 +96,30 @@ public:
         Fish,
         Water
     };
+    /** Tells clients which resources to reveal:
+     * Nothing - reveal nothing
+     * Ores - reveal ores
+     * Fish - reveal ores and fish
+     * Water - reveal ores, fish and water
+     */
     ResourceRevealMode getResourceRevealMode() const;
     void toggleResourceRevealMode();
 
     using PlayerIDSet = std::unordered_set<unsigned>;
+    /** Destroys all buildings of given players, effectively defeating them.
+     *
+     * @param playerIds - Set of IDs of players.
+     */
     void destroyBuildings(const PlayerIDSet& playerIds);
+    /** Destroys all buildings of AI players.
+     */
     void destroyAllAIBuildings();
 
 private:
+    /** Checks if cheats can be turned on at all.
+     *
+     * @return true if if cheats can be turned on, false otherwise
+     */
     bool canCheatModeBeOn() const;
 
     std::unique_ptr<CheatCommandTracker> cheatCmdTracker_;

--- a/libs/s25main/Cheats.h
+++ b/libs/s25main/Cheats.h
@@ -34,7 +34,18 @@ public:
 
     // RTTR cheats
     void toggleHumanAIPlayer();
+
     void armageddon();
+
+    enum class ResourceRevealMode
+    {
+        Nothing,
+        Ores,
+        Fish,
+        Water
+    };
+    ResourceRevealMode getResourceRevealMode() const;
+    void toggleResourceRevealMode();
 
 private:
     bool canCheatModeBeOn() const;
@@ -43,4 +54,5 @@ private:
     bool isCheatModeOn_ = false;
     bool isAllVisible_ = false;
     GameWorldBase& world_;
+    ResourceRevealMode resourceRevealMode_ = ResourceRevealMode::Nothing;
 };

--- a/libs/s25main/Cheats.h
+++ b/libs/s25main/Cheats.h
@@ -7,6 +7,7 @@
 #include "gameTypes/MapCoordinates.h"
 #include <memory>
 #include <string>
+#include <unordered_set>
 
 class CheatCommandTracker;
 class GamePlayer;
@@ -46,6 +47,10 @@ public:
     };
     ResourceRevealMode getResourceRevealMode() const;
     void toggleResourceRevealMode();
+
+    using PlayerIDSet = std::unordered_set<unsigned>;
+    void destroyBuildings(const PlayerIDSet& playerIds);
+    void destroyAllAIBuildings();
 
 private:
     bool canCheatModeBeOn() const;

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -2244,6 +2244,11 @@ void GamePlayer::Trade(nobBaseWarehouse* goalWh, const boost_variant2<GoodType, 
     }
 }
 
+bool GamePlayer::IsBuildingEnabled(BuildingType type) const
+{
+    return building_enabled[type] || GetGameWorld().IsCheatModeOn();
+}
+
 void GamePlayer::FillVisualSettings(VisualSettings& visualSettings) const
 {
     Distributions& visDistribution = visualSettings.distribution;

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -13,6 +13,7 @@
 #include "Ware.h"
 #include "addons/const_addons.h"
 #include "buildings/noBuildingSite.h"
+#include "buildings/nobHQ.h"
 #include "buildings/nobHarborBuilding.h"
 #include "buildings/nobMilitary.h"
 #include "buildings/nobUsual.h"
@@ -376,6 +377,19 @@ void GamePlayer::RemoveBuildingSite(noBuildingSite* bldSite)
     buildings.Remove(bldSite);
 }
 
+bool GamePlayer::IsHQTent() const
+{
+    if(const nobHQ* hq = GetHQ())
+        return hq->IsTent();
+    return false;
+}
+
+void GamePlayer::SetHQIsTent(bool isTent)
+{
+    if(nobHQ* hq = GetHQ())
+        hq->SetIsTent(isTent);
+}
+
 void GamePlayer::AddBuilding(noBuilding* bld, BuildingType bldType)
 {
     RTTR_Assert(bld->GetPlayer() == GetPlayerId());
@@ -395,8 +409,13 @@ void GamePlayer::AddBuilding(noBuilding* bld, BuildingType bldType)
         for(noShip* ship : ships)
             ship->NewHarborBuilt(static_cast<nobHarborBuilding*>(bld));
     } else if(bldType == BuildingType::Headquarters)
-        hqPos = bld->GetPos();
-    else if(BuildingProperties::IsMilitary(bldType))
+    {
+        // If there is more than one HQ, keep the original position.
+        if(!hqPos.isValid())
+        {
+            hqPos = bld->GetPos();
+        }
+    } else if(BuildingProperties::IsMilitary(bldType))
     {
         auto* milBld = static_cast<nobMilitary*>(bld);
         // New built? -> Calculate frontier distance
@@ -1363,6 +1382,12 @@ void GamePlayer::TestDefeat()
     // Keine Militärgebäude, keine Lagerhäuser (HQ,Häfen) -> kein Land --> verloren
     if(!isDefeated && buildings.GetMilitaryBuildings().empty() && buildings.GetStorehouses().empty())
         Surrender();
+}
+
+nobHQ* GamePlayer::GetHQ() const
+{
+    const MapPoint& hqPos = GetHQPos();
+    return const_cast<nobHQ*>(hqPos.isValid() ? GetGameWorld().GetSpecObj<nobHQ>(hqPos) : nullptr);
 }
 
 void GamePlayer::Surrender()

--- a/libs/s25main/GamePlayer.h
+++ b/libs/s25main/GamePlayer.h
@@ -289,7 +289,7 @@ public:
 
     void EnableBuilding(BuildingType type) { building_enabled[type] = true; }
     void DisableBuilding(BuildingType type) { building_enabled[type] = false; }
-    bool IsBuildingEnabled(BuildingType type) const { return building_enabled[type]; }
+    bool IsBuildingEnabled(BuildingType type) const;
     /// Set the area the player may have territory in
     /// Nothing means all is allowed. See Lua description
     std::vector<MapPoint>& GetRestrictedArea() { return restricted_area; }

--- a/libs/s25main/GamePlayer.h
+++ b/libs/s25main/GamePlayer.h
@@ -31,6 +31,7 @@ class noShip;
 class nobBaseMilitary;
 class nobBaseWarehouse;
 class nobHarborBuilding;
+class nobHQ;
 class nobMilitary;
 class nofCarrier;
 class nofFlagWorker;
@@ -91,6 +92,9 @@ public:
     const GameWorld& GetGameWorld() const { return world; }
 
     const MapPoint& GetHQPos() const { return hqPos; }
+    bool IsHQTent() const;
+    void SetHQIsTent(bool isTent);
+
     void AddBuilding(noBuilding* bld, BuildingType bldType);
     void RemoveBuilding(noBuilding* bld, BuildingType bldType);
     void AddBuildingSite(noBuildingSite* bldSite);
@@ -426,6 +430,7 @@ private:
     bool FindWarehouseForJob(Job job, noRoadNode* goal) const;
     /// Prüft, ob der Spieler besiegt wurde
     void TestDefeat();
+    nobHQ* GetHQ() const;
 
     //////////////////////////////////////////////////////////////////////////
     /// Unsynchronized state (e.g. lua, gui...)

--- a/libs/s25main/buildings/noBaseBuilding.cpp
+++ b/libs/s25main/buildings/noBaseBuilding.cpp
@@ -60,9 +60,21 @@ noBaseBuilding::noBaseBuilding(const NodalObjectType nop, const BuildingType typ
     {
         for(const Direction i : {Direction::West, Direction::NorthWest, Direction::NorthEast})
         {
-            MapPoint pos2 = world->GetNeighbour(pos, i);
-            world->DestroyNO(pos2, false);
-            world->SetNO(pos2, new noExtension(this));
+            const MapPoint neighbor = world->GetNeighbour(pos, i);
+
+            if(type == BuildingType::Headquarters)
+            {
+                const NodalObjectType neighborNoType = world->GetNO(neighbor)->GetType();
+                // Don't replace nearby static objects or trees. Needed for "build headquarters" cheat to work like in
+                // the original. This situation shouldn't happen any other way (can't normally build big buildings right
+                // next to static objects or trees). Trees which be remain because of this will be replaced by
+                // extensions instead of stumps if they are cut while still right next to the HQ.
+                if(neighborNoType == NodalObjectType::Object || neighborNoType == NodalObjectType::Tree)
+                    continue;
+            }
+
+            world->DestroyNO(neighbor, false);
+            world->SetNO(neighbor, new noExtension(this));
         }
     }
 }
@@ -220,7 +232,9 @@ void noBaseBuilding::DestroyBuildingExtensions()
     {
         for(const Direction i : {Direction::West, Direction::NorthWest, Direction::NorthEast})
         {
-            world->DestroyNO(world->GetNeighbour(pos, i));
+            const MapPoint neighbor = world->GetNeighbour(pos, i);
+            if(world->GetNO(neighbor)->GetType() == NodalObjectType::Extension)
+                world->DestroyNO(neighbor);
         }
     }
 }

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "dskGameInterface.h"
+#include "Cheats.h"
 #include "CollisionDetection.h"
 #include "EventManager.h"
 #include "Game.h"
@@ -102,8 +103,7 @@ dskGameInterface::dskGameInterface(std::shared_ptr<Game> game, std::shared_ptr<c
     : Desktop(nullptr), game_(std::move(game)), nwfInfo_(std::move(nwfInfo)),
       worldViewer(playerIdx, const_cast<Game&>(*game_).world_),
       gwv(worldViewer, Position(0, 0), VIDEODRIVER.GetRenderSize()), cbb(*LOADER.GetPaletteN("pal5")),
-      actionwindow(nullptr), roadwindow(nullptr), minimap(worldViewer), isScrolling(false), zoomLvl(ZOOM_DEFAULT_INDEX),
-      isCheatModeOn(false)
+      actionwindow(nullptr), roadwindow(nullptr), minimap(worldViewer), isScrolling(false), zoomLvl(ZOOM_DEFAULT_INDEX)
 {
     road.mode = RoadBuildMode::Disabled;
     road.point = MapPoint(0, 0);
@@ -409,7 +409,7 @@ void dskGameInterface::Msg_PaintAfter()
     DrawPoint iconPos(VIDEODRIVER.GetRenderSize().x - 56, 32);
 
     // Draw cheating indicator icon (WINTER)
-    if(isCheatModeOn)
+    if(world.IsCheatModeOn())
     {
         glArchivItem_Bitmap* cheatingImg = LOADER.GetImageN("io", 75);
         cheatingImg->DrawFull(iconPos);
@@ -720,6 +720,8 @@ bool dskGameInterface::Msg_RightUp(const MouseCoords& /*mc*/) //-V524
  */
 bool dskGameInterface::Msg_KeyDown(const KeyEvent& ke)
 {
+    game_->world_.GetCheats().trackKeyEvent(ke);
+
     switch(ke.kt)
     {
         default: break;
@@ -757,45 +759,12 @@ bool dskGameInterface::Msg_KeyDown(const KeyEvent& ke)
         case KeyType::F9: // Readme
             WINDOWMANAGER.ToggleWindow(std::make_unique<iwTextfile>("readme.txt", _("Readme!")));
             return true;
-        case KeyType::F10:
-        {
-#ifdef NDEBUG
-            const bool allowHumanAI = isCheatModeOn;
-#else
-            const bool allowHumanAI = true;
-#endif // !NDEBUG
-            if(GAMECLIENT.GetState() == ClientState::Game && allowHumanAI && !GAMECLIENT.IsReplayModeOn())
-                GAMECLIENT.ToggleHumanAIPlayer(AI::Info(AI::Type::Default, AI::Level::Easy));
-            return true;
-        }
         case KeyType::F11: // Music player (midi files)
             WINDOWMANAGER.ToggleWindow(std::make_unique<iwMusicPlayer>());
             return true;
         case KeyType::F12: // Optionsfenster
             WINDOWMANAGER.ToggleWindow(std::make_unique<iwOptionsWindow>(gwv.GetSoundMgr()));
             return true;
-    }
-
-    static std::string winterCheat = "winter";
-    switch(ke.c)
-    {
-        case 'w':
-        case 'i':
-        case 'n':
-        case 't':
-        case 'e':
-        case 'r':
-            curCheatTxt += char(ke.c);
-            if(winterCheat.find(curCheatTxt) == 0)
-            {
-                if(curCheatTxt == winterCheat)
-                {
-                    isCheatModeOn = !isCheatModeOn;
-                    curCheatTxt.clear();
-                }
-            } else
-                curCheatTxt.clear();
-            break;
     }
 
     switch(ke.c)
@@ -1109,9 +1078,9 @@ void dskGameInterface::ShowActionWindow(const iwAction::Tabs& action_tabs, MapPo
 
 void dskGameInterface::OnChatCommand(const std::string& cmd)
 {
-    if(cmd == "apocalypsis")
-        GAMECLIENT.CheatArmageddon();
-    else if(cmd == "surrender")
+    game_->world_.GetCheats().trackChatCommand(cmd);
+
+    if(cmd == "surrender")
         GAMECLIENT.Surrender();
     else if(cmd == "async")
         (void)RANDOM.Rand(RANDOM_CONTEXT2(0), 255);

--- a/libs/s25main/desktops/dskGameInterface.h
+++ b/libs/s25main/desktops/dskGameInterface.h
@@ -161,7 +161,5 @@ protected:
     bool isScrolling;
     Position startScrollPt;
     size_t zoomLvl;
-    bool isCheatModeOn;
-    std::string curCheatTxt;
     Subscription evBld;
 };

--- a/libs/s25main/factories/BuildingFactory.cpp
+++ b/libs/s25main/factories/BuildingFactory.cpp
@@ -13,12 +13,12 @@
 #include "world/GameWorldBase.h"
 
 noBuilding* BuildingFactory::CreateBuilding(GameWorldBase& world, const BuildingType type, const MapPoint pt,
-                                            const unsigned char player, const Nation nation)
+                                            const unsigned char player, const Nation nation, bool isTent)
 {
     noBuilding* bld;
     switch(type)
     {
-        case BuildingType::Headquarters: bld = new nobHQ(pt, player, nation); break;
+        case BuildingType::Headquarters: bld = new nobHQ(pt, player, nation, isTent); break;
         case BuildingType::Storehouse: bld = new nobStorehouse(pt, player, nation); break;
         case BuildingType::HarborBuilding: bld = new nobHarborBuilding(pt, player, nation); break;
         case BuildingType::Barracks:

--- a/libs/s25main/factories/BuildingFactory.h
+++ b/libs/s25main/factories/BuildingFactory.h
@@ -21,5 +21,5 @@ public:
     BuildingFactory() = delete;
 
     static noBuilding* CreateBuilding(GameWorldBase& world, BuildingType type, MapPoint pt, unsigned char player,
-                                      Nation nation);
+                                      Nation nation, bool isTent = false);
 };

--- a/libs/s25main/ingameWindows/iwAction.cpp
+++ b/libs/s25main/ingameWindows/iwAction.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "iwAction.h"
+#include "Cheats.h"
 #include "GameInterface.h"
 #include "GamePlayer.h"
 #include "GlobalGameSettings.h"
@@ -38,7 +39,8 @@ enum TabID
     TAB_FLAG,
     TAB_CUTROAD,
     TAB_ATTACK,
-    TAB_SEAATTACK
+    TAB_SEAATTACK,
+    TAB_CHEAT
 };
 
 iwAction::iwAction(GameInterface& gi, GameWorldView& gwv, const Tabs& tabs, MapPoint selectedPt,
@@ -69,6 +71,8 @@ iwAction::iwAction(GameInterface& gi, GameWorldView& gwv, const Tabs& tabs, MapP
         TAB_ATTACK  3 = Option group: Better/Weaker
         TAB_ATTACK  4 = Angriff
         TAB_ATTACK  10-14 = Direktauswahl Anzahl
+
+        TAB_CHEAT   1 = Place cheat building
     */
 
     const GamePlayer& player = gwv.GetViewer().GetPlayer();
@@ -284,6 +288,15 @@ iwAction::iwAction(GameInterface& gi, GameWorldView& gwv, const Tabs& tabs, MapP
     // Beobachten-main_tab
     if(tabs.watch)
     {
+        if(gwv.GetWorld().GetCheats().canPlaceCheatBuilding(selectedPt))
+        {
+            constexpr auto buildImgId = 18;
+            const auto buildImg = LOADER.GetImageN("io", buildImgId);
+            ctrlGroup* group = main_tab->AddTab(buildImg, _("Build headquarters"), TAB_CHEAT);
+            group->AddImageButton(1, DrawPoint{0, 45}, Extent{180, 36}, TextureColor::Grey, buildImg,
+                                  _("Build headquarters"));
+        }
+
         ctrlGroup* group = main_tab->AddTab(LOADER.GetImageN("io", 36), _("Display options"), TAB_WATCH);
         const Extent btSize(45, 36);
         DrawPoint curPos(0, 45);
@@ -431,6 +444,12 @@ void iwAction::Msg_Group_ButtonClick(const unsigned /*group_id*/, const unsigned
             Msg_ButtonClick_TabWatch(ctrl_id);
         }
         break;
+
+        case TAB_CHEAT:
+        {
+            Msg_ButtonClick_TabCheat(ctrl_id);
+        }
+        break;
     }
 }
 
@@ -446,6 +465,7 @@ void iwAction::Msg_TabChange(const unsigned ctrl_id, const unsigned short tab_id
                 case TAB_FLAG:
                 case TAB_CUTROAD:
                 case TAB_SETFLAG:
+                case TAB_CHEAT:
                 case TAB_WATCH: height = 138; break;
                 case TAB_BUILD:
                 {
@@ -723,6 +743,17 @@ void iwAction::Msg_ButtonClick_TabWatch(const unsigned ctrl_id)
         case 4:
             if(GAMECLIENT.NotifyAlliesOfLocation(selectedPt))
                 Close();
+            break;
+    }
+}
+
+void iwAction::Msg_ButtonClick_TabCheat(const unsigned ctrl_id)
+{
+    switch(ctrl_id)
+    {
+        case 1:
+            gwv.GetWorld().GetCheats().placeCheatBuilding(selectedPt, gwv.GetViewer().GetPlayer());
+            Close();
             break;
     }
 }

--- a/libs/s25main/ingameWindows/iwAction.h
+++ b/libs/s25main/ingameWindows/iwAction.h
@@ -91,6 +91,7 @@ private:
     inline void Msg_ButtonClick_TabSeaAttack(unsigned ctrl_id);
     inline void Msg_ButtonClick_TabSetFlag(unsigned ctrl_id);
     inline void Msg_ButtonClick_TabWatch(unsigned ctrl_id);
+    inline void Msg_ButtonClick_TabCheat(unsigned ctrl_id);
 
     void DisableMousePosResetOnClose();
 

--- a/libs/s25main/lua/LuaPlayer.cpp
+++ b/libs/s25main/lua/LuaPlayer.cpp
@@ -261,13 +261,7 @@ bool LuaPlayer::AIConstructionOrder(unsigned x, unsigned y, lua::SafeEnum<Buildi
 
 void LuaPlayer::ModifyHQ(bool isTent)
 {
-    const MapPoint hqPos = player.GetHQPos();
-    if(hqPos.isValid())
-    {
-        auto* hq = player.GetGameWorld().GetSpecObj<nobHQ>(hqPos);
-        if(hq)
-            hq->SetIsTent(isTent);
-    }
+    player.SetHQIsTent(isTent);
 }
 
 bool LuaPlayer::IsDefeated() const

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -1148,44 +1148,51 @@ bool GameClient::OnGameMessage(const GameMessage_GameCommand& msg)
 
 void GameClient::IncreaseSpeed()
 {
-    const bool debugMode =
-#ifndef NDEBUG
-      true;
-#else
-      false;
-#endif
-    if(framesinfo.gfLengthReq > FramesInfo::milliseconds32_t(10))
-        framesinfo.gfLengthReq -= FramesInfo::milliseconds32_t(10);
-    else if((replayMode || debugMode) && framesinfo.gfLengthReq == FramesInfo::milliseconds32_t(10))
-        framesinfo.gfLengthReq = FramesInfo::milliseconds32_t(1);
-    else
-        framesinfo.gfLengthReq = FramesInfo::milliseconds32_t(70);
-
-    if(replayMode)
-        framesinfo.gf_length = framesinfo.gfLengthReq;
-    else
-        mainPlayer.sendMsgAsync(new GameMessage_Speed(framesinfo.gfLengthReq.count()));
+    //  1..10 -> 0
+    // 11..20 -> 10
+    // 21..30 -> 20 etc.
+    SetGFLengthReq((framesinfo.gfLengthReq - 1ms) / 10 * 10);
 }
 
 void GameClient::DecreaseSpeed()
 {
-    const bool debugMode =
+    //  1.. 9 -> 10
+    // 10..19 -> 20
+    // 20..29 -> 30 etc.
+    SetGFLengthReq(framesinfo.gfLengthReq / 10 * 10 + 10ms);
+}
+
+void GameClient::SetGFLengthReq(FramesInfo::milliseconds32_t gfLengthReq)
+{
 #ifndef NDEBUG
-      true;
+    constexpr auto minLength = 1ms;
 #else
-      false;
+    const auto minLength = IsReplayModeOn() ? 1ms : 10ms;
 #endif
 
-    FramesInfo::milliseconds32_t maxSpeed(replayMode ? 1000 : 70);
+    const auto maxLength = IsReplayModeOn() ? 1000ms : 70ms;
 
-    if(framesinfo.gfLengthReq == maxSpeed)
-        framesinfo.gfLengthReq = FramesInfo::milliseconds32_t(replayMode || debugMode ? 1 : 10);
-    else if(framesinfo.gfLengthReq == FramesInfo::milliseconds32_t(1))
-        framesinfo.gfLengthReq = FramesInfo::milliseconds32_t(10);
-    else
-        framesinfo.gfLengthReq += FramesInfo::milliseconds32_t(10);
+    if(gfLengthReq == 0ms)
+    {
+        // already at minimum? wrap around from min to max
+        if(framesinfo.gfLengthReq == minLength)
+            framesinfo.gfLengthReq = maxLength;
+        else // treat set 0 as set minimum
+            framesinfo.gfLengthReq = minLength;
+    } else if(gfLengthReq < minLength) // clamp to min
+    {
+        framesinfo.gfLengthReq = minLength;
+    } else if(gfLengthReq > maxLength)
+    {
+        // already at maximum? wrap around from max to min
+        if(framesinfo.gfLengthReq == maxLength)
+            framesinfo.gfLengthReq = minLength;
+        else // clamp to max
+            framesinfo.gfLengthReq = maxLength;
+    } else
+        framesinfo.gfLengthReq = gfLengthReq;
 
-    if(replayMode)
+    if(IsReplayModeOn())
         framesinfo.gf_length = framesinfo.gfLengthReq;
     else
         mainPlayer.sendMsgAsync(new GameMessage_Speed(framesinfo.gfLengthReq.count()));

--- a/libs/s25main/network/GameClient.h
+++ b/libs/s25main/network/GameClient.h
@@ -127,8 +127,14 @@ public:
     /// And a 2nd time when the GUI is ready which actually starty the game
     void OnGameStart();
 
+    // Used by + and v
     void IncreaseSpeed();
+    // Used by -
     void DecreaseSpeed();
+    // Used by ALT+1 through ALT+6 (cheats)
+    void SetGFLengthReq(FramesInfo::milliseconds32_t);
+    // Used by tests (stinks, but what to do?)
+    FramesInfo::milliseconds32_t GetGFLengthReq() { return framesinfo.gfLengthReq; }
 
     /// Lädt ein Replay und startet dementsprechend das Spiel
     bool StartReplay(const boost::filesystem::path& path);

--- a/libs/s25main/world/GameWorldBase.cpp
+++ b/libs/s25main/world/GameWorldBase.cpp
@@ -4,6 +4,7 @@
 
 #include "world/GameWorldBase.h"
 #include "BQCalculator.h"
+#include "Cheats.h"
 #include "GamePlayer.h"
 #include "GlobalGameSettings.h"
 #include "MapGeometry.h"
@@ -29,7 +30,8 @@
 
 GameWorldBase::GameWorldBase(std::vector<GamePlayer> players, const GlobalGameSettings& gameSettings, EventManager& em)
     : roadPathFinder(new RoadPathFinder(*this)), freePathFinder(new FreePathFinder(*this)), players(std::move(players)),
-      gameSettings(gameSettings), em(em), soundManager(std::make_unique<SoundManager>()), lua(nullptr), gi(nullptr)
+      gameSettings(gameSettings), em(em), soundManager(std::make_unique<SoundManager>()), lua(nullptr),
+      cheats(std::make_unique<Cheats>()), gi(nullptr)
 {}
 
 GameWorldBase::~GameWorldBase() = default;
@@ -254,6 +256,11 @@ const noFlag* GameWorldBase::GetRoadFlag(MapPoint pt, Direction& dir, helpers::O
 Position GameWorldBase::GetNodePos(const MapPoint pt) const
 {
     return ::GetNodePos(pt, GetNode(pt).altitude);
+}
+
+bool GameWorldBase::IsCheatModeOn() const
+{
+    return cheats->isCheatModeOn();
 }
 
 void GameWorldBase::VisibilityChanged(const MapPoint pt, unsigned player, Visibility /*oldVis*/, Visibility /*newVis*/)

--- a/libs/s25main/world/GameWorldBase.cpp
+++ b/libs/s25main/world/GameWorldBase.cpp
@@ -31,7 +31,7 @@
 GameWorldBase::GameWorldBase(std::vector<GamePlayer> players, const GlobalGameSettings& gameSettings, EventManager& em)
     : roadPathFinder(new RoadPathFinder(*this)), freePathFinder(new FreePathFinder(*this)), players(std::move(players)),
       gameSettings(gameSettings), em(em), soundManager(std::make_unique<SoundManager>()), lua(nullptr),
-      cheats(std::make_unique<Cheats>()), gi(nullptr)
+      cheats(std::make_unique<Cheats>(*this)), gi(nullptr)
 {}
 
 GameWorldBase::~GameWorldBase() = default;

--- a/libs/s25main/world/GameWorldBase.cpp
+++ b/libs/s25main/world/GameWorldBase.cpp
@@ -172,6 +172,14 @@ bool GameWorldBase::IsFlagAround(const MapPoint& pt) const
     return false;
 }
 
+bool GameWorldBase::IsAnyNeighborOwned(const MapPoint& pt) const
+{
+    for(const MapPoint& nb : GetNeighbours(pt))
+        if(GetNode(nb).owner)
+            return true;
+    return false;
+}
+
 void GameWorldBase::RecalcBQForRoad(const MapPoint pt)
 {
     RecalcBQ(pt);

--- a/libs/s25main/world/GameWorldBase.h
+++ b/libs/s25main/world/GameWorldBase.h
@@ -79,7 +79,7 @@ public:
     // Remaining initialization after loading (BQ...)
     void InitAfterLoad();
 
-    /// Setzt GameInterface
+    GameInterface* GetGameInterface() { return gi; }
     void SetGameInterface(GameInterface* const gi) { this->gi = gi; }
 
     /// Get the economy mode handler if set.

--- a/libs/s25main/world/GameWorldBase.h
+++ b/libs/s25main/world/GameWorldBase.h
@@ -94,7 +94,7 @@ public:
     bool IsOnRoad(const MapPoint& pt) const;
     /// Check if a flag is at a neighbour node
     bool IsFlagAround(const MapPoint& pt) const;
-
+    bool IsAnyNeighborOwned(const MapPoint& pt) const;
     /// Berechnet BQ bei einer gebauten Stra�e
     void RecalcBQForRoad(MapPoint pt);
     /// Pr�ft, ob sich in unmittelbarer N�he (im Radius von 4) Milit�rgeb�ude befinden

--- a/libs/s25main/world/GameWorldBase.h
+++ b/libs/s25main/world/GameWorldBase.h
@@ -94,7 +94,14 @@ public:
     bool IsOnRoad(const MapPoint& pt) const;
     /// Check if a flag is at a neighbour node
     bool IsFlagAround(const MapPoint& pt) const;
+
+    /** Checks if any of the neighboring nodes of a given map point are owned by any player.
+     *
+     * @param pt - The map point whose neighbors should be checked.
+     * @return true if any neighbor has an owner, false otherwise
+     */
     bool IsAnyNeighborOwned(const MapPoint& pt) const;
+
     /// Berechnet BQ bei einer gebauten Stra�e
     void RecalcBQForRoad(MapPoint pt);
     /// Pr�ft, ob sich in unmittelbarer N�he (im Radius von 4) Milit�rgeb�ude befinden

--- a/libs/s25main/world/GameWorldBase.h
+++ b/libs/s25main/world/GameWorldBase.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <vector>
 
+class Cheats;
 class EventManager;
 class FreePathFinder;
 class GameInterface;
@@ -59,6 +60,7 @@ class GameWorldBase : public World
     EventManager& em;
     std::unique_ptr<SoundManager> soundManager;
     LuaInterfaceGame* lua;
+    std::unique_ptr<Cheats> cheats;
 
 protected:
     /// Interface zum GUI
@@ -212,6 +214,9 @@ public:
     bool HasLua() const { return lua != nullptr; }
     LuaInterfaceGame& GetLua() const { return *lua; }
     void SetLua(LuaInterfaceGame* newLua) { lua = newLua; }
+
+    Cheats& GetCheats() const { return *cheats; }
+    bool IsCheatModeOn() const;
 
 protected:
     /// Called when the visibility of point changed for a player

--- a/libs/s25main/world/GameWorldView.cpp
+++ b/libs/s25main/world/GameWorldView.cpp
@@ -195,6 +195,9 @@ void GameWorldView::Draw(const RoadBuildState& rb, const MapPoint selected, bool
 
             for(IDrawNodeCallback* callback : drawNodeCallbacks)
                 callback->onDraw(curPt, curPos);
+
+            if(visibility == Visibility::Visible)
+                DrawResource(curPt, curPos, GetWorld().GetCheats().getResourceRevealMode());
         }
 
         // Figuren zwischen den Zeilen zeichnen
@@ -556,6 +559,54 @@ void GameWorldView::DrawBoundaryStone(const MapPoint& pt, const DrawPoint pos, V
         else
             continue;
         LOADER.boundary_stone_cache[nation].draw(curPos, isFoW ? FOW_DRAW_COLOR : COLOR_WHITE, player_color);
+    }
+}
+
+void GameWorldView::DrawResource(const MapPoint& pt, DrawPoint curPos, Cheats::ResourceRevealMode resRevealMode)
+{
+    using RRM = Cheats::ResourceRevealMode;
+
+    if(resRevealMode == RRM::Nothing)
+        return;
+
+    const Resource res = gwv.GetNode(pt).resources;
+    const auto amount = res.getAmount();
+
+    if(!amount)
+        return;
+
+    GoodType gt = GoodType::Nothing;
+
+    switch(res.getType())
+    {
+        case ResourceType::Iron: gt = GoodType::IronOre; break;
+        case ResourceType::Gold: gt = GoodType::Gold; break;
+        case ResourceType::Coal: gt = GoodType::Coal; break;
+        case ResourceType::Granite: gt = GoodType::Stones; break;
+        case ResourceType::Water:
+            if(resRevealMode >= RRM::Water)
+            {
+                gt = GoodType::Water;
+                break;
+            } else
+                return;
+        case ResourceType::Fish:
+            if(resRevealMode >= RRM::Fish)
+            {
+                gt = GoodType::Fish;
+                break;
+            } else
+                return;
+        default: return;
+    }
+
+    if(auto bm = LOADER.GetWareTex(gt))
+    {
+        for(auto i = 0u; i < amount; ++i)
+        {
+            bm->DrawFull(curPos);
+            curPos.y -= 4;
+        }
     }
 }
 

--- a/libs/s25main/world/GameWorldView.cpp
+++ b/libs/s25main/world/GameWorldView.cpp
@@ -370,7 +370,9 @@ void GameWorldView::DrawNameProductivityOverlay(const TerrainRenderer& terrainRe
                     auto* attackAidImage = LOADER.GetImageN("map_new", 20000);
                     attackAidImage->DrawFull(curPos - DrawPoint(0, attackAidImage->getHeight()));
                 }
-                continue;
+                // DO draw when object visible and cheat mode is on
+                if(gwv.GetVisibility(pt) != Visibility::Visible || !GetWorld().IsCheatModeOn())
+                    continue;
             }
 
             // Draw object name

--- a/libs/s25main/world/GameWorldView.h
+++ b/libs/s25main/world/GameWorldView.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "Cheats.h"
 #include "DrawPoint.h"
 #include "gameTypes/MapCoordinates.h"
 #include "gameTypes/MapTypes.h"
@@ -127,6 +128,7 @@ public:
 private:
     void CalcFxLx();
     void DrawBoundaryStone(const MapPoint& pt, DrawPoint pos, Visibility vis);
+    void DrawResource(const MapPoint& pt, DrawPoint curPos, Cheats::ResourceRevealMode resRevealMode);
     void DrawObject(const MapPoint& pt, const DrawPoint& curPos) const;
     void DrawConstructionAid(const MapPoint& pt, const DrawPoint& curPos);
     void DrawFigures(const MapPoint& pt, const DrawPoint& curPos, std::vector<ObjectBetweenLines>& between_lines) const;

--- a/libs/s25main/world/GameWorldViewer.cpp
+++ b/libs/s25main/world/GameWorldViewer.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "world/GameWorldViewer.h"
+#include "Cheats.h"
 #include "GamePlayer.h"
 #include "GlobalGameSettings.h"
 #include "RttrForeachPt.h"
@@ -113,6 +114,9 @@ BuildingQuality GameWorldViewer::GetBQ(const MapPoint& pt) const
 
 Visibility GameWorldViewer::GetVisibility(const MapPoint pt) const
 {
+    if(GetWorld().GetCheats().isAllVisible())
+        return Visibility::Visible;
+
     /// Replaymodus und FoW aus? Dann alles sichtbar
     if(GAMECLIENT.IsReplayModeOn() && GAMECLIENT.IsReplayFOWDisabled())
         return Visibility::Visible;

--- a/tests/s25Main/integration/testCheatCommandTracker.cpp
+++ b/tests/s25Main/integration/testCheatCommandTracker.cpp
@@ -5,14 +5,15 @@
 #include "CheatCommandTracker.h"
 #include "Cheats.h"
 #include "driver/KeyEvent.h"
-#include <boost/test/unit_test.hpp>
+#include "worldFixtures/CreateEmptyWorld.h"
+#include "worldFixtures/WorldFixture.h"
 
 BOOST_AUTO_TEST_SUITE(CheatsTests)
 
 namespace {
-struct CheatCommandTrackerFixture
+struct CheatCommandTrackerFixture : WorldFixture<CreateEmptyWorld, 1>
 {
-    Cheats cheats_;
+    Cheats cheats_{world};
     CheatCommandTracker tracker_{cheats_};
 
     KeyEvent makeKeyEvent(unsigned c) { return {KeyType::Char, c, 0, 0, 0}; }

--- a/tests/s25Main/integration/testCheats.cpp
+++ b/tests/s25Main/integration/testCheats.cpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "Cheats.h"
+#include "GamePlayer.h"
+#include "network/GameClient.h"
+#include "worldFixtures/CreateEmptyWorld.h"
+#include "worldFixtures/WorldFixture.h"
+
+namespace {
+template<unsigned T_numPlayers>
+struct CheatWorldFixture : WorldFixture<CreateEmptyWorld, T_numPlayers>
+{
+    Cheats& cheats = world.GetCheats();
+};
+
+using CheatWorldFixture1P = CheatWorldFixture<1>;
+using CheatWorldFixture2P = CheatWorldFixture<2>;
+} // namespace
+
+BOOST_FIXTURE_TEST_CASE(CheatModeIsOffByDefault, CheatWorldFixture1P)
+{
+    BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CanToggleCheatModeOn, CheatWorldFixture1P)
+{
+    cheats.toggleCheatMode();
+    BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == true);
+}
+
+BOOST_FIXTURE_TEST_CASE(CannotToggleCheatModeOn_IfMultiplayer, CheatWorldFixture2P)
+{
+    cheats.toggleCheatMode();
+    BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CanToggleCheatModeOnAndOff, CheatWorldFixture1P)
+{
+    cheats.toggleCheatMode();
+    BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == true);
+    cheats.toggleCheatMode();
+    BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CanToggleCheatModeOnAndOffRepeatedly, CheatWorldFixture1P)
+{
+    cheats.toggleCheatMode();
+    BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == true);
+    cheats.toggleCheatMode();
+    BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == false);
+    cheats.toggleCheatMode();
+    BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == true);
+    cheats.toggleCheatMode();
+    BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == false);
+}

--- a/tests/s25Main/integration/testCheats.cpp
+++ b/tests/s25Main/integration/testCheats.cpp
@@ -4,46 +4,46 @@
 
 #include "Cheats.h"
 #include "GamePlayer.h"
+#include "buildings/nobHQ.h"
 #include "desktops/dskGameInterface.h"
 #include "network/GameClient.h"
 #include "worldFixtures/CreateEmptyWorld.h"
 #include "worldFixtures/WorldFixture.h"
+#include "gameData/MilitaryConsts.h"
 #include <turtle/mock.hpp>
 
 namespace {
-MOCK_BASE_CLASS(MockGameInterface, GameInterface)
-{
-    MOCK_METHOD(GI_PlayerDefeated, 1)
-    MOCK_METHOD(GI_UpdateMinimap, 1)
-    MOCK_METHOD(GI_FlagDestroyed, 1)
-    MOCK_METHOD(GI_TreatyOfAllianceChanged, 1)
-    MOCK_METHOD(GI_UpdateMapVisibility, 0)
-    MOCK_METHOD(GI_Winner, 1)
-    MOCK_METHOD(GI_TeamWinner, 1)
-    MOCK_METHOD(GI_StartRoadBuilding, 2)
-    MOCK_METHOD(GI_CancelRoadBuilding, 0)
-    MOCK_METHOD(GI_BuildRoad, 0)
-};
-
 constexpr auto worldWidth = 64;
 constexpr auto worldHeight = 64;
 struct CheatWorldFixture : WorldFixture<CreateEmptyWorld, 2, worldWidth, worldHeight>
 {
+    CheatWorldFixture() { p2.ps = PlayerState::AI; }
+
     Cheats& cheats = world.GetCheats();
 
     dskGameInterface gameDesktop{game, 0, 0, 0};
     const GameWorldViewer& viewer = gameDesktop.GetView().GetViewer();
 
-    MockGameInterface mgi;
-
     GamePlayer& getPlayer(unsigned id) { return world.GetPlayer(id); }
     GamePlayer& p1 = getPlayer(0);
     GamePlayer& p2 = getPlayer(1);
 
-    CheatWorldFixture()
+    const MapPoint p1HQPos = p1.GetHQPos();
+    const MapPoint p2HQPos = p2.GetHQPos();
+
+    MapPoint unownedPt = {static_cast<MapCoord>(p1HQPos.x + HQ_RADIUS + 2), p1HQPos.y};
+
+    auto countHQs(const GamePlayer& player)
     {
-        p2.ps = PlayerState::AI;
-        world.SetGameInterface(&mgi);
+        return player.GetBuildingRegister().GetBuildingNums().buildings[BuildingType::Headquarters];
+    }
+    auto getHQs(const GamePlayer& player)
+    {
+        std::vector<nobHQ*> ret;
+        for(auto bld : player.GetBuildingRegister().GetStorehouses())
+            if(bld->GetBuildingType() == BuildingType::Headquarters)
+                ret.push_back(static_cast<nobHQ*>(bld));
+        return ret;
     }
 };
 } // namespace
@@ -86,9 +86,25 @@ BOOST_FIXTURE_TEST_CASE(CanToggleCheatModeOnAndOffRepeatedly, CheatWorldFixture)
     BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == false);
 }
 
+MOCK_BASE_CLASS(MockGameInterface, GameInterface)
+{
+    MOCK_METHOD(GI_PlayerDefeated, 1)
+    MOCK_METHOD(GI_UpdateMinimap, 1)
+    MOCK_METHOD(GI_FlagDestroyed, 1)
+    MOCK_METHOD(GI_TreatyOfAllianceChanged, 1)
+    MOCK_METHOD(GI_UpdateMapVisibility, 0)
+    MOCK_METHOD(GI_Winner, 1)
+    MOCK_METHOD(GI_TeamWinner, 1)
+    MOCK_METHOD(GI_StartRoadBuilding, 2)
+    MOCK_METHOD(GI_CancelRoadBuilding, 0)
+    MOCK_METHOD(GI_BuildRoad, 0)
+};
+
 BOOST_FIXTURE_TEST_CASE(CanToggleAllVisible_IfCheatModeIsOn, CheatWorldFixture)
 {
-    const MapPoint p1HQPos = world.GetPlayer(0).GetHQPos();
+    MockGameInterface mgi;
+    world.SetGameInterface(&mgi);
+
     MapPoint farawayPos = p1HQPos;
     farawayPos.x += 20;
     BOOST_TEST_REQUIRE((viewer.GetVisibility(p1HQPos) == Visibility::Visible) == true);
@@ -106,8 +122,10 @@ BOOST_FIXTURE_TEST_CASE(CanToggleAllVisible_IfCheatModeIsOn, CheatWorldFixture)
 
 BOOST_FIXTURE_TEST_CASE(CannotToggleAllVisible_IfCheatModeIsNotOn, CheatWorldFixture)
 {
+    MockGameInterface mgi;
+    world.SetGameInterface(&mgi);
+
     MOCK_EXPECT(mgi.GI_UpdateMapVisibility).never();
-    const MapPoint p1HQPos = world.GetPlayer(0).GetHQPos();
     MapPoint farawayPos = p1HQPos;
     farawayPos.x += 20;
     BOOST_TEST_REQUIRE((viewer.GetVisibility(p1HQPos) == Visibility::Visible) == true);
@@ -115,4 +133,98 @@ BOOST_FIXTURE_TEST_CASE(CannotToggleAllVisible_IfCheatModeIsNotOn, CheatWorldFix
     cheats.toggleAllVisible();
     BOOST_TEST_REQUIRE((viewer.GetVisibility(p1HQPos) == Visibility::Visible) == true);
     BOOST_TEST_REQUIRE((viewer.GetVisibility(farawayPos) == Visibility::Visible) == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CannotPlaceCheatBuildingWithinOwnedTerritory, CheatWorldFixture)
+{
+    cheats.toggleCheatMode();
+
+    MapPoint p1territory = p1HQPos;
+    p1territory.x += 3;
+    p1territory.y += 3;
+    BOOST_TEST_REQUIRE(cheats.canPlaceCheatBuilding(p1territory) == false);
+
+    MapPoint p2territory = p2HQPos;
+    p2territory.x += 3;
+    p2territory.y += 3;
+    BOOST_TEST_REQUIRE(cheats.canPlaceCheatBuilding(p2territory) == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CannotPlaceCheatBuildingAtTerritoryBorderOrOneNodeFurther, CheatWorldFixture)
+{
+    cheats.toggleCheatMode();
+
+    MapPoint border = p1HQPos;
+    border.x += HQ_RADIUS;
+    BOOST_TEST_REQUIRE(cheats.canPlaceCheatBuilding(border) == false);
+
+    MapPoint nodeBeyondBorder = border;
+    ++border.x;
+    BOOST_TEST_REQUIRE(cheats.canPlaceCheatBuilding(nodeBeyondBorder) == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CanPlaceCheatBuildingOutsideOwnedTerritory, CheatWorldFixture)
+{
+    cheats.toggleCheatMode();
+    BOOST_TEST_REQUIRE(cheats.canPlaceCheatBuilding(unownedPt) == true);
+}
+
+BOOST_FIXTURE_TEST_CASE(CannotPlaceCheatBuilding_IfCheatModeIsNotOn, CheatWorldFixture)
+{
+    BOOST_TEST_REQUIRE(cheats.canPlaceCheatBuilding(unownedPt) == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(PlacesHQAsACheatBuilding, CheatWorldFixture)
+{
+    cheats.toggleCheatMode();
+    BOOST_TEST_REQUIRE(countHQs(p1) == 1);
+    cheats.placeCheatBuilding(unownedPt, p1);
+    BOOST_TEST_REQUIRE(countHQs(p1) == 2);
+}
+
+BOOST_FIXTURE_TEST_CASE(DoesNotPlaceHQAsACheatBuilding_IfCheatModeIsNotOn, CheatWorldFixture)
+{
+    BOOST_TEST_REQUIRE(countHQs(p1) == 1);
+    cheats.placeCheatBuilding(unownedPt, p1);
+    BOOST_TEST_REQUIRE(countHQs(p1) == 1);
+}
+
+BOOST_FIXTURE_TEST_CASE(CanPlaceCheatBuildingForAnyPlayer, CheatWorldFixture)
+{
+    cheats.toggleCheatMode();
+    BOOST_TEST_REQUIRE(countHQs(p1) == 1);
+    BOOST_TEST_REQUIRE(countHQs(p2) == 1);
+    cheats.placeCheatBuilding(unownedPt, p2);
+    BOOST_TEST_REQUIRE(countHQs(p1) == 1);
+    BOOST_TEST_REQUIRE(countHQs(p2) == 2);
+    unownedPt.x -= 2 * (HQ_RADIUS + 2);
+    cheats.placeCheatBuilding(unownedPt, p1);
+    BOOST_TEST_REQUIRE(countHQs(p1) == 2);
+    BOOST_TEST_REQUIRE(countHQs(p2) == 2);
+}
+
+BOOST_FIXTURE_TEST_CASE(CheatBuildingHasTheSameNation, CheatWorldFixture)
+{
+    cheats.toggleCheatMode();
+    cheats.placeCheatBuilding(unownedPt, p1);
+    for(auto bld : getHQs(p1))
+        BOOST_TEST_REQUIRE((bld->GetNation() == p1.nation) == true);
+}
+
+BOOST_FIXTURE_TEST_CASE(CheatBuildingIsATent_IfPrimaryHQIsATent, CheatWorldFixture)
+{
+    p1.SetHQIsTent(true);
+    cheats.toggleCheatMode();
+    cheats.placeCheatBuilding(unownedPt, p1);
+    for(auto bld : getHQs(p1))
+        BOOST_TEST_REQUIRE(static_cast<nobHQ*>(bld)->IsTent() == true);
+}
+
+BOOST_FIXTURE_TEST_CASE(CheatBuildingIsNotATent_IfPrimaryHQIsNotATent, CheatWorldFixture)
+{
+    p1.SetHQIsTent(false);
+    cheats.toggleCheatMode();
+    cheats.placeCheatBuilding(unownedPt, p1);
+    for(auto bld : getHQs(p1))
+        BOOST_TEST_REQUIRE(static_cast<nobHQ*>(bld)->IsTent() == false);
 }

--- a/tests/s25Main/integration/testCheats.cpp
+++ b/tests/s25Main/integration/testCheats.cpp
@@ -228,3 +228,27 @@ BOOST_FIXTURE_TEST_CASE(CheatBuildingIsNotATent_IfPrimaryHQIsNotATent, CheatWorl
     for(auto bld : getHQs(p1))
         BOOST_TEST_REQUIRE(static_cast<nobHQ*>(bld)->IsTent() == false);
 }
+
+BOOST_FIXTURE_TEST_CASE(CanToggleResourcesToRevealSuccessively, CheatWorldFixture)
+{
+    using RRM = Cheats::ResourceRevealMode;
+
+    BOOST_CHECK(cheats.getResourceRevealMode() == RRM::Nothing);
+    cheats.toggleCheatMode();
+    BOOST_CHECK(cheats.getResourceRevealMode() == RRM::Nothing);
+    cheats.toggleResourceRevealMode();
+    BOOST_CHECK(cheats.getResourceRevealMode() == RRM::Ores);
+    cheats.toggleResourceRevealMode();
+    BOOST_CHECK(cheats.getResourceRevealMode() == RRM::Fish);
+    cheats.toggleResourceRevealMode();
+    BOOST_CHECK(cheats.getResourceRevealMode() == RRM::Water);
+    cheats.toggleResourceRevealMode();
+    BOOST_CHECK(cheats.getResourceRevealMode() == RRM::Nothing);
+    cheats.toggleResourceRevealMode();
+    BOOST_CHECK(cheats.getResourceRevealMode() == RRM::Ores);
+    cheats.toggleCheatMode();
+    BOOST_CHECK(cheats.getResourceRevealMode() == RRM::Nothing);
+    cheats.toggleResourceRevealMode();
+    cheats.toggleCheatMode();
+    BOOST_CHECK(cheats.getResourceRevealMode() == RRM::Fish);
+}

--- a/tests/s25Main/integration/testCheats.cpp
+++ b/tests/s25Main/integration/testCheats.cpp
@@ -4,39 +4,69 @@
 
 #include "Cheats.h"
 #include "GamePlayer.h"
+#include "desktops/dskGameInterface.h"
 #include "network/GameClient.h"
 #include "worldFixtures/CreateEmptyWorld.h"
 #include "worldFixtures/WorldFixture.h"
+#include <turtle/mock.hpp>
 
 namespace {
-template<unsigned T_numPlayers>
-struct CheatWorldFixture : WorldFixture<CreateEmptyWorld, T_numPlayers>
+MOCK_BASE_CLASS(MockGameInterface, GameInterface)
 {
-    Cheats& cheats = world.GetCheats();
+    MOCK_METHOD(GI_PlayerDefeated, 1)
+    MOCK_METHOD(GI_UpdateMinimap, 1)
+    MOCK_METHOD(GI_FlagDestroyed, 1)
+    MOCK_METHOD(GI_TreatyOfAllianceChanged, 1)
+    MOCK_METHOD(GI_UpdateMapVisibility, 0)
+    MOCK_METHOD(GI_Winner, 1)
+    MOCK_METHOD(GI_TeamWinner, 1)
+    MOCK_METHOD(GI_StartRoadBuilding, 2)
+    MOCK_METHOD(GI_CancelRoadBuilding, 0)
+    MOCK_METHOD(GI_BuildRoad, 0)
 };
 
-using CheatWorldFixture1P = CheatWorldFixture<1>;
-using CheatWorldFixture2P = CheatWorldFixture<2>;
+constexpr auto worldWidth = 64;
+constexpr auto worldHeight = 64;
+struct CheatWorldFixture : WorldFixture<CreateEmptyWorld, 2, worldWidth, worldHeight>
+{
+    Cheats& cheats = world.GetCheats();
+
+    dskGameInterface gameDesktop{game, 0, 0, 0};
+    const GameWorldViewer& viewer = gameDesktop.GetView().GetViewer();
+
+    MockGameInterface mgi;
+
+    GamePlayer& getPlayer(unsigned id) { return world.GetPlayer(id); }
+    GamePlayer& p1 = getPlayer(0);
+    GamePlayer& p2 = getPlayer(1);
+
+    CheatWorldFixture()
+    {
+        p2.ps = PlayerState::AI;
+        world.SetGameInterface(&mgi);
+    }
+};
 } // namespace
 
-BOOST_FIXTURE_TEST_CASE(CheatModeIsOffByDefault, CheatWorldFixture1P)
+BOOST_FIXTURE_TEST_CASE(CheatModeIsOffByDefault, CheatWorldFixture)
 {
     BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == false);
 }
 
-BOOST_FIXTURE_TEST_CASE(CanToggleCheatModeOn, CheatWorldFixture1P)
+BOOST_FIXTURE_TEST_CASE(CanToggleCheatModeOn, CheatWorldFixture)
 {
     cheats.toggleCheatMode();
     BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == true);
 }
 
-BOOST_FIXTURE_TEST_CASE(CannotToggleCheatModeOn_IfMultiplayer, CheatWorldFixture2P)
+BOOST_FIXTURE_TEST_CASE(CannotToggleCheatModeOn_IfMultiplayer, CheatWorldFixture)
 {
+    p2.ps = PlayerState::Occupied;
     cheats.toggleCheatMode();
     BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == false);
 }
 
-BOOST_FIXTURE_TEST_CASE(CanToggleCheatModeOnAndOff, CheatWorldFixture1P)
+BOOST_FIXTURE_TEST_CASE(CanToggleCheatModeOnAndOff, CheatWorldFixture)
 {
     cheats.toggleCheatMode();
     BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == true);
@@ -44,7 +74,7 @@ BOOST_FIXTURE_TEST_CASE(CanToggleCheatModeOnAndOff, CheatWorldFixture1P)
     BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == false);
 }
 
-BOOST_FIXTURE_TEST_CASE(CanToggleCheatModeOnAndOffRepeatedly, CheatWorldFixture1P)
+BOOST_FIXTURE_TEST_CASE(CanToggleCheatModeOnAndOffRepeatedly, CheatWorldFixture)
 {
     cheats.toggleCheatMode();
     BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == true);
@@ -54,4 +84,35 @@ BOOST_FIXTURE_TEST_CASE(CanToggleCheatModeOnAndOffRepeatedly, CheatWorldFixture1
     BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == true);
     cheats.toggleCheatMode();
     BOOST_TEST_REQUIRE(cheats.isCheatModeOn() == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CanToggleAllVisible_IfCheatModeIsOn, CheatWorldFixture)
+{
+    const MapPoint p1HQPos = world.GetPlayer(0).GetHQPos();
+    MapPoint farawayPos = p1HQPos;
+    farawayPos.x += 20;
+    BOOST_TEST_REQUIRE((viewer.GetVisibility(p1HQPos) == Visibility::Visible) == true);
+    BOOST_TEST_REQUIRE((viewer.GetVisibility(farawayPos) == Visibility::Visible) == false);
+    cheats.toggleCheatMode();
+    MOCK_EXPECT(mgi.GI_UpdateMapVisibility).once();
+    cheats.toggleAllVisible();
+    BOOST_TEST_REQUIRE((viewer.GetVisibility(p1HQPos) == Visibility::Visible) == true);
+    BOOST_TEST_REQUIRE((viewer.GetVisibility(farawayPos) == Visibility::Visible) == true);
+    MOCK_EXPECT(mgi.GI_UpdateMapVisibility).once();
+    cheats.toggleAllVisible();
+    BOOST_TEST_REQUIRE((viewer.GetVisibility(p1HQPos) == Visibility::Visible) == true);
+    BOOST_TEST_REQUIRE((viewer.GetVisibility(farawayPos) == Visibility::Visible) == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CannotToggleAllVisible_IfCheatModeIsNotOn, CheatWorldFixture)
+{
+    MOCK_EXPECT(mgi.GI_UpdateMapVisibility).never();
+    const MapPoint p1HQPos = world.GetPlayer(0).GetHQPos();
+    MapPoint farawayPos = p1HQPos;
+    farawayPos.x += 20;
+    BOOST_TEST_REQUIRE((viewer.GetVisibility(p1HQPos) == Visibility::Visible) == true);
+    BOOST_TEST_REQUIRE((viewer.GetVisibility(farawayPos) == Visibility::Visible) == false);
+    cheats.toggleAllVisible();
+    BOOST_TEST_REQUIRE((viewer.GetVisibility(p1HQPos) == Visibility::Visible) == true);
+    BOOST_TEST_REQUIRE((viewer.GetVisibility(farawayPos) == Visibility::Visible) == false);
 }

--- a/tests/s25Main/integration/testGamePlayer.cpp
+++ b/tests/s25Main/integration/testGamePlayer.cpp
@@ -119,3 +119,28 @@ BOOST_FIXTURE_TEST_CASE(ProductivityStats, WorldFixtureEmpty1P)
     BOOST_TEST(buildingRegister.CalcProductivities() == expectedProductivity, per_element());
     BOOST_TEST(buildingRegister.CalcAverageProductivity() == avgProd);
 }
+
+BOOST_FIXTURE_TEST_CASE(IsHQTent_ReturnsFalse_IfPrimaryHQIsNotTent, WorldFixtureEmpty1P)
+{
+    GamePlayer& p1 = world.GetPlayer(0);
+
+    // place another HQ that is a tent
+    MapPoint newHqPos = p1.GetHQPos();
+    newHqPos.x += 3;
+    BuildingFactory::CreateBuilding(world, BuildingType::Headquarters, newHqPos, 0, Nation::Babylonians, true);
+
+    BOOST_TEST_REQUIRE(p1.IsHQTent() == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(IsHQTent_ReturnsTrue_IfPrimaryHQIsTent, WorldFixtureEmpty1P)
+{
+    GamePlayer& p1 = world.GetPlayer(0);
+    p1.SetHQIsTent(true);
+
+    // place another HQ that is not a tent
+    MapPoint newHqPos = p1.GetHQPos();
+    newHqPos.x += 3;
+    BuildingFactory::CreateBuilding(world, BuildingType::Headquarters, newHqPos, 0, Nation::Babylonians, false);
+
+    BOOST_TEST_REQUIRE(p1.IsHQTent() == true);
+}

--- a/tests/s25Main/integration/testGamePlayer.cpp
+++ b/tests/s25Main/integration/testGamePlayer.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "Cheats.h"
 #include "GamePlayer.h"
 #include "buildings/nobBaseWarehouse.h"
 #include "buildings/nobMilitary.h"
@@ -143,4 +144,16 @@ BOOST_FIXTURE_TEST_CASE(IsHQTent_ReturnsTrue_IfPrimaryHQIsTent, WorldFixtureEmpt
     BuildingFactory::CreateBuilding(world, BuildingType::Headquarters, newHqPos, 0, Nation::Babylonians, false);
 
     BOOST_TEST_REQUIRE(p1.IsHQTent() == true);
+}
+
+BOOST_FIXTURE_TEST_CASE(AllBuildingsAreEnabled_WhenCheatModeIsOn, WorldFixtureEmpty1P)
+{
+    GamePlayer& p1 = world.GetPlayer(0);
+    const auto bld = BuildingType::Brewery;
+    p1.DisableBuilding(bld);
+    BOOST_TEST_REQUIRE(p1.IsBuildingEnabled(bld) == false);
+    world.GetCheats().toggleCheatMode();
+    BOOST_TEST_REQUIRE(p1.IsBuildingEnabled(bld) == true);
+    world.GetCheats().toggleCheatMode();
+    BOOST_TEST_REQUIRE(p1.IsBuildingEnabled(bld) == false);
 }

--- a/tests/s25Main/simple/testCheatCommandTracker.cpp
+++ b/tests/s25Main/simple/testCheatCommandTracker.cpp
@@ -1,0 +1,117 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "CheatCommandTracker.h"
+#include "Cheats.h"
+#include "driver/KeyEvent.h"
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(CheatsTests)
+
+namespace {
+struct CheatCommandTrackerFixture
+{
+    Cheats cheats_;
+    CheatCommandTracker tracker_{cheats_};
+
+    KeyEvent makeKeyEvent(unsigned c) { return {KeyType::Char, c, 0, 0, 0}; }
+    KeyEvent makeKeyEvent(KeyType kt) { return {kt, 0, 0, 0, 0}; }
+
+    void trackString(const std::string& str)
+    {
+        for(char c : str)
+            tracker_.trackKeyEvent(makeKeyEvent(c));
+    }
+};
+
+} // namespace
+
+BOOST_FIXTURE_TEST_CASE(CheatModeIsOffByDefault, CheatCommandTrackerFixture)
+{
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CheatModeCanBeTurnedOn, CheatCommandTrackerFixture)
+{
+    trackString("winter");
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == true);
+}
+
+BOOST_FIXTURE_TEST_CASE(CheatModeCanBeTurnedOff, CheatCommandTrackerFixture)
+{
+    trackString("winter");
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == true);
+    trackString("winter");
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CheatModeCanBeTurnedOnAndOffRepeatedly, CheatCommandTrackerFixture)
+{
+    trackString("winter");
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == true);
+    trackString("winter");
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == false);
+    trackString("winter");
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == true);
+    trackString("winter");
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CheatModeIsNotTurnedOn_WhenIncomplete, CheatCommandTrackerFixture)
+{
+    trackString("winte");
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CheatModeIsNotTurnedOn_WhenInterruptedByAnotherKeyType, CheatCommandTrackerFixture)
+{
+    trackString("win");
+    tracker_.trackKeyEvent(makeKeyEvent(KeyType::F10));
+    trackString("ter");
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CheatModeIsNotTurnedOn_WhenInterruptedByAnotherLetter, CheatCommandTrackerFixture)
+{
+    trackString("wainter");
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CheatModeIsNotTurnedOn_WhenOrderOfCharactersIsWrong, CheatCommandTrackerFixture)
+{
+    trackString("winetr");
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CheatModeIsNotTurnedOn_WhenOrderOfCharactersIsWrong_Wraparound, CheatCommandTrackerFixture)
+{
+    trackString("rwinet");
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CheatModeIsNotTurnedOn_WhenACharacterIsRepeated, CheatCommandTrackerFixture)
+{
+    trackString("winnter");
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(CheatModeIsTurnedOn_WhenTheFirstCharacterIsRepeated, CheatCommandTrackerFixture)
+{
+    trackString("wwwinter");
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == true);
+}
+
+BOOST_FIXTURE_TEST_CASE(CheatModeIsTurnedOn_EvenWhenWrongInputsWereProvidedBefore, CheatCommandTrackerFixture)
+{
+    trackString("www");
+    auto ke = makeKeyEvent('1');
+    ke.alt = true;
+    tracker_.trackKeyEvent(ke);
+    trackString("interwitter");
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == false);
+    trackString("winter");
+    BOOST_TEST_REQUIRE(cheats_.isCheatModeOn() == true);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- refactored existing cheat code ("winter" code, toggle human AI player, armageddon) into new Cheats and CheatCommandTracker classes
- added classic (S2) cheats:
  - all-visible (F7) - [video](https://streamable.com/464uxc)
  - build headquarters - [video](https://streamable.com/1u9l86)
  - show enemy productivity overlay - [video](https://streamable.com/ihv4xl)
  - enable all buildings - [video](https://streamable.com/98prx7)
  - set speed by using ALT-1 .. ALT-6
- added new (RttR) cheats:
  - reveal resources - [video](https://streamable.com/ehxa4o)
  - destroy buildings (kinda similar to armageddon) - [video](https://streamable.com/4ojiaj)

I would happily split these cheats into separate PR's, but they all rely on the refactoring, so at least the first few commits would have to be merged before any split can be done.

The all-visible and build HQ cheats are useful for testing campaign scripts, which I have also been working on. The remaining S2 cheats are there mostly for feature parity and setting speed does not work the same as it did in S2 (certainly not fast enough, probably steps are different too).

The reveal resources cheat can be useful not only in gameplay but in debugging as well and the destroy buildings cheat is useful for testing the world campaign progress where the player needs to achieve total domination but also not destroy themselves (as they would with the armageddon cheat).