### PR TITLE
Add support for campaign status

### DIFF
--- a/data/RTTR/campaigns/roman/MISS200.lua
+++ b/data/RTTR/campaigns/roman/MISS200.lua
@@ -508,9 +508,9 @@ function MissionEvent(e, onLoad)
         rttr:GetPlayer(0):EnableBuilding(BLD_BAKERY, not onLoad)
 
     elseif(e == 99) then
-        -- TODO: EnableNextMissions()
         -- Show opened arc
         rttr:GetWorld():AddStaticObject(14, 8, 561, 0xFFFF, 2)
+        rttr:SetCampaignChapterCompleted("roman", 1)
     end
 
     -- update event state

--- a/data/RTTR/campaigns/roman/MISS201.lua
+++ b/data/RTTR/campaigns/roman/MISS201.lua
@@ -6,7 +6,6 @@
 
 
 -------------------------------- TODO -----------------------------------------
--- EnableNextMissions()
 -- Set Portraits
 -- Set AI Agression Level
 -- RttR: AI doesn't go south
@@ -514,9 +513,10 @@ function MissionEvent(e, onLoad)
         rttr:GetPlayer(1):DisableBuilding(BLD_CATAPULT, false)
 
     elseif(e == 99) then
-        -- TODO: EnableNextMissions()
         -- Show opened arc
         rttr:GetWorld():AddStaticObject(48, 9, 561, 0xFFFF, 2)
+        rttr:SetCampaignChapterCompleted("roman", 2)
+        rttr:EnableCampaignChapter("roman", 3)
     end
 
     -- update event state

--- a/data/RTTR/campaigns/roman/MISS202.lua
+++ b/data/RTTR/campaigns/roman/MISS202.lua
@@ -6,7 +6,6 @@
 
 
 -------------------------------- TODO -----------------------------------------
--- EnableNextMissions()
 -- Set Portraits
 -- Set AI Agression Level
 -------------------------------------------------------------------------------
@@ -521,9 +520,10 @@ function MissionEvent(e, onLoad)
         rttr:GetPlayer(2):SetRestrictedArea()
 
     elseif(e == 99) then
-        -- TODO: EnableNextMissions()
         -- Show opened arc
         rttr:GetWorld():AddStaticObject(89, 20, 561, 0xFFFF, 2)
+        rttr:SetCampaignChapterCompleted("roman", 3)
+        rttr:EnableCampaignChapter("roman", 4)
     end
 
     -- update event state

--- a/data/RTTR/campaigns/roman/MISS203.lua
+++ b/data/RTTR/campaigns/roman/MISS203.lua
@@ -6,7 +6,6 @@
 
 
 -------------------------------- TODO -----------------------------------------
--- EnableNextMissions()
 -- Set Portraits
 -- Set AI Agression Level
 -------------------------------------------------------------------------------
@@ -513,9 +512,10 @@ function MissionEvent(e, onLoad)
         rttr:GetPlayer(2):SetRestrictedArea()
 
     elseif(e == 99) then
-        -- TODO: EnableNextMissions()
         -- Show opened arc
         rttr:GetWorld():AddStaticObject(97, 68, 561, 0xFFFF, 2)
+        rttr:SetCampaignChapterCompleted("roman", 4)
+        rttr:EnableCampaignChapter("roman", 5)
     end
 
     -- update event state

--- a/data/RTTR/campaigns/roman/MISS204.lua
+++ b/data/RTTR/campaigns/roman/MISS204.lua
@@ -6,7 +6,6 @@
 
 
 -------------------------------- TODO -----------------------------------------
--- EnableNextMissions()
 -- Set Portraits
 -- Set AI Agression Level
 -------------------------------------------------------------------------------
@@ -433,9 +432,10 @@ function MissionEvent(e, onLoad)
 
     -- call side effects for active events, check "eState[e] == 1" for multiple call events!
     if(e == 99) then
-        -- TODO: EnableNextMissions()
         -- Show opened arc
         rttr:GetWorld():AddStaticObject(19, 37, 561, 0xFFFF, 2)
+        rttr:SetCampaignChapterCompleted("roman", 5)
+        rttr:EnableCampaignChapter("roman", 6)
     end
 
     -- update event state

--- a/data/RTTR/campaigns/roman/MISS205.lua
+++ b/data/RTTR/campaigns/roman/MISS205.lua
@@ -6,7 +6,6 @@
 
 
 -------------------------------- TODO -----------------------------------------
--- EnableNextMissions()
 -- Set Portraits
 -- Set AI Agression Level
 -------------------------------------------------------------------------------
@@ -559,9 +558,10 @@ function MissionEvent(e, onLoad)
     
     -- call side effects for active events, check "eState[e] == 1" for multiple call events!
     elseif(e == 99) then
-        -- TODO: EnableNextMissions()
         -- Show opened arc
         rttr:GetWorld():AddStaticObject(148, 50, 561, 0xFFFF, 2)
+        rttr:SetCampaignChapterCompleted("roman", 6)
+        rttr:EnableCampaignChapter("roman", 7)
     end
 
     -- update event state

--- a/data/RTTR/campaigns/roman/MISS206.lua
+++ b/data/RTTR/campaigns/roman/MISS206.lua
@@ -6,7 +6,6 @@
 
 
 -------------------------------- TODO -----------------------------------------
--- EnableNextMissions()
 -- Set Portraits
 -- Set AI Agression Level
 -------------------------------------------------------------------------------
@@ -490,9 +489,10 @@ function MissionEvent(e, onLoad)
 
     -- call side effects for active events, check "eState[e] == 1" for multiple call events!
     elseif(e == 99) then
-        -- TODO: EnableNextMissions()
         -- Show opened arc
         rttr:GetWorld():AddStaticObject(13, 66, 561, 0xFFFF, 2)
+        rttr:SetCampaignChapterCompleted("roman", 7)
+        rttr:EnableCampaignChapter("roman", 8)
     end
 
     -- update event state

--- a/data/RTTR/campaigns/roman/MISS207.lua
+++ b/data/RTTR/campaigns/roman/MISS207.lua
@@ -6,7 +6,6 @@
 
 
 -------------------------------- TODO -----------------------------------------
--- EnableNextMissions()
 -- Set Portraits
 -- Set AI Agression Level
 -------------------------------------------------------------------------------
@@ -441,9 +440,10 @@ function MissionEvent(e, onLoad)
         rttr:GetPlayer(2):SetRestrictedArea()
 
     elseif(e == 99) then
-        -- TODO: EnableNextMissions()
         -- Show opened arc
         rttr:GetWorld():AddStaticObject(11, 125, 561, 0xFFFF, 2)
+        rttr:SetCampaignChapterCompleted("roman", 8)
+        rttr:EnableCampaignChapter("roman", 9)
     end
 
     -- update event state

--- a/data/RTTR/campaigns/roman/MISS208.lua
+++ b/data/RTTR/campaigns/roman/MISS208.lua
@@ -6,7 +6,6 @@
 
 
 -------------------------------- TODO -----------------------------------------
--- EnableNextMissions()
 -- Set Portraits
 -- Set AI Agression Level
 -------------------------------------------------------------------------------
@@ -441,9 +440,10 @@ function MissionEvent(e, onLoad)
         rttr:GetPlayer(2):SetRestrictedArea()
 
     elseif(e == 99) then
-        -- TODO: EnableNextMissions()
         -- Show opened arc - Done
         rttr:GetWorld():AddStaticObject(127, 48, 561, 0xFFFF, 2)
+        rttr:SetCampaignChapterCompleted("roman", 9)
+        rttr:EnableCampaignChapter("roman", 10)
     end
 
     -- update event state

--- a/data/RTTR/campaigns/roman/MISS209.lua
+++ b/data/RTTR/campaigns/roman/MISS209.lua
@@ -6,7 +6,6 @@
 
 
 -------------------------------- TODO -----------------------------------------
--- EnableNextMissions()
 -- Set Portraits
 -- Set AI Agression Level
 -------------------------------------------------------------------------------
@@ -469,9 +468,10 @@ function MissionEvent(e, onLoad)
         rttr:GetPlayer(2):SetRestrictedArea()
         
     elseif(e == 99) then
-        -- TODO: EnableNextMissions()
         -- Show opened arc
         rttr:GetWorld():AddStaticObject(75, 40, 561, 0xFFFF, 2)
+        rttr:SetCampaignChapterCompleted("roman", 10)
+        rttr:SetCampaignCompleted("roman")
     end
 
     -- update event state

--- a/data/RTTR/campaigns/roman/campaign.lua
+++ b/data/RTTR/campaigns/roman/campaign.lua
@@ -21,6 +21,7 @@ rttr:RegisterTranslations(
 
 campaign = {
     version = 1,
+    uid = "roman",
     author = "Bluebyte",
     name = _"name",
     shortDescription = _"shortDescription",

--- a/data/RTTR/campaigns/world/AFRICA.lua
+++ b/data/RTTR/campaigns/world/AFRICA.lua
@@ -66,3 +66,9 @@ function getAllowedChanges()
         ["aiTeam"]      = false
     }
 end
+
+-------------------------------- mission events -------------------------------
+function onHumanWinner()
+    rttr:SetCampaignChapterCompleted("world", 2)
+    rttr:EnableCampaignChapter("world", 8) -- sasia
+end

--- a/data/RTTR/campaigns/world/AUSTRA.lua
+++ b/data/RTTR/campaigns/world/AUSTRA.lua
@@ -54,3 +54,10 @@ function getAllowedChanges()
         ["aiTeam"]      = false
     }
 end
+
+-------------------------------- mission events -------------------------------
+function onHumanWinner()
+    rttr:SetCampaignChapterCompleted("world", 6)
+    rttr:EnableCampaignChapter("world", 8) -- sasia
+    rttr:EnableCampaignChapter("world", 9) -- japan
+end

--- a/data/RTTR/campaigns/world/EUROPE.lua
+++ b/data/RTTR/campaigns/world/EUROPE.lua
@@ -78,3 +78,11 @@ function getAllowedChanges()
         ["aiTeam"]      = false
     }
 end
+
+-------------------------------- mission events -------------------------------
+function onHumanWinner()
+    rttr:SetCampaignChapterCompleted("world", 1)
+    rttr:EnableCampaignChapter("world", 2) -- africa
+    rttr:EnableCampaignChapter("world", 5) -- green
+    rttr:EnableCampaignChapter("world", 7) -- nasia
+end

--- a/data/RTTR/campaigns/world/GREEN.lua
+++ b/data/RTTR/campaigns/world/GREEN.lua
@@ -54,3 +54,9 @@ function getAllowedChanges()
         ["aiTeam"]      = false
     }
 end
+
+-------------------------------- mission events -------------------------------
+function onHumanWinner()
+    rttr:SetCampaignChapterCompleted("world", 5)
+    rttr:EnableCampaignChapter("world", 3) -- namerica
+end

--- a/data/RTTR/campaigns/world/JAPAN.lua
+++ b/data/RTTR/campaigns/world/JAPAN.lua
@@ -54,3 +54,10 @@ function getAllowedChanges()
         ["aiTeam"]      = false
     }
 end
+
+-------------------------------- mission events -------------------------------
+function onHumanWinner()
+    rttr:SetCampaignChapterCompleted("world", 9)
+    rttr:EnableCampaignChapter("world", 6) -- austra
+    rttr:EnableCampaignChapter("world", 7) -- nasia
+end

--- a/data/RTTR/campaigns/world/NAMERICA.lua
+++ b/data/RTTR/campaigns/world/NAMERICA.lua
@@ -60,3 +60,10 @@ function getAllowedChanges()
         ["aiTeam"]      = false
     }
 end
+
+-------------------------------- mission events -------------------------------
+function onHumanWinner()
+    rttr:SetCampaignChapterCompleted("world", 3)
+    rttr:EnableCampaignChapter("world", 4) -- samerica
+    rttr:EnableCampaignChapter("world", 5) -- green
+end

--- a/data/RTTR/campaigns/world/NASIA.lua
+++ b/data/RTTR/campaigns/world/NASIA.lua
@@ -66,3 +66,10 @@ function getAllowedChanges()
         ["aiTeam"]      = false
     }
 end
+
+-------------------------------- mission events -------------------------------
+function onHumanWinner()
+    rttr:SetCampaignChapterCompleted("world", 7)
+    rttr:EnableCampaignChapter("world", 8) -- sasia
+    rttr:EnableCampaignChapter("world", 9) -- japan
+end

--- a/data/RTTR/campaigns/world/SAMERICA.lua
+++ b/data/RTTR/campaigns/world/SAMERICA.lua
@@ -60,3 +60,9 @@ function getAllowedChanges()
         ["aiTeam"]      = false
     }
 end
+
+-------------------------------- mission events -------------------------------
+function onHumanWinner()
+    rttr:SetCampaignChapterCompleted("world", 4)
+    rttr:EnableCampaignChapter("world", 3) -- namerica
+end

--- a/data/RTTR/campaigns/world/SASIA.lua
+++ b/data/RTTR/campaigns/world/SASIA.lua
@@ -60,3 +60,11 @@ function getAllowedChanges()
         ["aiTeam"]      = false
     }
 end
+
+-------------------------------- mission events -------------------------------
+function onHumanWinner()
+    rttr:SetCampaignChapterCompleted("world", 8)
+    rttr:EnableCampaignChapter("world", 2) -- africa
+    rttr:EnableCampaignChapter("world", 6) -- austra
+    rttr:EnableCampaignChapter("world", 7) -- nasia
+end

--- a/data/RTTR/campaigns/world/campaign.lua
+++ b/data/RTTR/campaigns/world/campaign.lua
@@ -21,6 +21,7 @@ rttr:RegisterTranslations(
 
 campaign = {
     version = 1,
+    uid = "world",
     author = "Bluebyte",
     name = _"name",
     shortDescription = _"shortDescription",
@@ -30,7 +31,8 @@ campaign = {
     difficulty = "easy",
     mapFolder = "<RTTR_GAME>/DATA/MAPS2",
     luaFolder = "<RTTR_RTTR>/CAMPAIGNS/WORLD",
-    maps = { "EUROPE.WLD","NAMERICA.WLD","SAMERICA.WLD","GREEN.WLD","AFRICA.WLD","NASIA.WLD","SASIA.WLD","JAPAN.WLD","AUSTRA.WLD"},
+    maps = { "EUROPE.WLD","AFRICA.WLD","NAMERICA.WLD","SAMERICA.WLD","GREEN.WLD","AUSTRA.WLD","NASIA.WLD","SASIA.WLD","JAPAN.WLD"},
+    defaultChaptersEnabled = "100000000",
     selectionMap = {
         background = {"<RTTR_GAME>/GFX/PICS/SETUP990.LBM", 0},
         map = {"<RTTR_GAME>/GFX/PICS/WORLD.LBM", 0},
@@ -40,15 +42,15 @@ campaign = {
         backgroundOffset = {64, 70},
         disabledColor = 0x70000000,
         missionSelectionInfos = {
-            {0xffffff00, 243, 97},
-            {0xffaf73cb, 55,78},
-            {0xff008fc3, 122, 193},
-            {0xff43c373, 166, 36},
-            {0xff27871b, 241,176},
-            {0xffc32323, 366,87},
-            {0xff573327, 375,145},
-            {0xffcfaf4b, 486, 136},
-            {0xffbb6313, 441, 264}
+            {0xffffff00, 243, 97},  -- europe
+            {0xff27871b, 241,176},  -- africa
+            {0xffaf73cb, 55,78},    -- namerica
+            {0xff008fc3, 122, 193}, -- samerica
+            {0xff43c373, 166, 36},  -- green
+            {0xffbb6313, 441, 264}, -- austra
+            {0xffc32323, 366,87},   -- nasia
+            {0xff573327, 375,145},  -- sasia
+            {0xffcfaf4b, 486, 136}  -- japan
         }
     }
 }

--- a/doc/lua/events.md
+++ b/doc/lua/events.md
@@ -107,3 +107,6 @@ Called when a pact has been canceled.
 
 **onPactCreated(PactType, suggestedByPlayerIdx, targetPlayerIdx, duration)**  
 Called when a pact has been confirmed.
+
+**onHumanWinner()**
+Called when the game is won by a human.

--- a/libs/libGamedata/gameData/CampaignDescription.cpp
+++ b/libs/libGamedata/gameData/CampaignDescription.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "CampaignDescription.h"
+#include "CampaignSaveCodes.h"
 #include "RttrConfig.h"
 #include "helpers/format.hpp"
 #include "lua/CheckedLuaTable.h"
@@ -12,6 +13,7 @@
 CampaignDescription::CampaignDescription(const kaguya::LuaRef& table)
 {
     CheckedLuaTable luaData(table);
+    luaData.getOrThrow(uid, "uid");
     luaData.getOrThrow(version, "version");
     luaData.getOrThrow(author, "author");
     luaData.getOrThrow(name, "name");
@@ -33,6 +35,8 @@ CampaignDescription::CampaignDescription(const kaguya::LuaRef& table)
     lua::validatePath(mapFolder);
     lua::validatePath(luaFolder);
     mapNames = luaData.getOrDefault("maps", std::vector<std::string>());
+    defaultChaptersEnabled =
+      luaData.getOrDefault("defaultChaptersEnabled", std::string{CampaignSaveCodes::defaultChaptersEnabled});
     selectionMapData = luaData.getOptional<SelectionMapInputData>("selectionMap");
     luaData.checkUnused();
 }

--- a/libs/libGamedata/gameData/CampaignDescription.h
+++ b/libs/libGamedata/gameData/CampaignDescription.h
@@ -15,6 +15,7 @@ class LuaRef;
 
 struct CampaignDescription
 {
+    std::string uid;
     std::string version;
     std::string author;
     std::string name;
@@ -23,6 +24,7 @@ struct CampaignDescription
     std::string image;
     unsigned maxHumanPlayers = 0;
     std::string difficulty;
+    std::string defaultChaptersEnabled;
     std::optional<SelectionMapInputData> selectionMapData;
 
     CampaignDescription() = default;

--- a/libs/libGamedata/gameData/CampaignSaveCodes.h
+++ b/libs/libGamedata/gameData/CampaignSaveCodes.h
@@ -1,0 +1,12 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+namespace CampaignSaveCodes {
+constexpr auto chapterDisabled = '0';
+constexpr auto chapterEnabled = '1';
+constexpr auto chapterCompleted = '2';
+constexpr auto defaultChaptersEnabled = "1100000000";
+} // namespace CampaignSaveCodes

--- a/libs/s25main/CampaignSaveData.cpp
+++ b/libs/s25main/CampaignSaveData.cpp
@@ -1,0 +1,45 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "CampaignSaveData.h"
+#include "Settings.h"
+#include "gameData/CampaignDescription.h"
+#include "gameData/CampaignSaveCodes.h"
+
+namespace {
+auto getCampaignSaveData(const CampaignDescription& campaignDesc)
+{
+    auto& saveData = SETTINGS.campaigns.saveData;
+
+    if(!saveData.count(campaignDesc.uid))
+        saveData[campaignDesc.uid] = campaignDesc.defaultChaptersEnabled;
+
+    return saveData[campaignDesc.uid];
+}
+} // namespace
+
+bool isChapterEnabled(const CampaignDescription& campaignDesc, unsigned char chapter)
+{
+    const auto& saveData = getCampaignSaveData(campaignDesc);
+
+    if(chapter >= saveData.length())
+        return false;
+
+    return saveData[chapter] != CampaignSaveCodes::chapterDisabled;
+}
+
+std::vector<MissionStatus> getMissionsStatus(const CampaignDescription& campaignDesc)
+{
+    const auto& saveData = getCampaignSaveData(campaignDesc);
+
+    std::vector<MissionStatus> ret(saveData.length());
+    for(auto i = 0u; i < saveData.length(); ++i)
+    {
+        ret[i].playable = saveData[i] != CampaignSaveCodes::chapterDisabled;
+        ret[i].conquered = saveData[i] == CampaignSaveCodes::chapterCompleted;
+    }
+
+    ret.resize(campaignDesc.getNumMaps());
+    return ret;
+}

--- a/libs/s25main/CampaignSaveData.h
+++ b/libs/s25main/CampaignSaveData.h
@@ -1,0 +1,12 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "controls/ctrlMapSelection.h"
+
+struct CampaignDescription;
+
+bool isChapterEnabled(const CampaignDescription& campaignDesc, unsigned char chapter);
+std::vector<MissionStatus> getMissionsStatus(const CampaignDescription& campaignDesc);

--- a/libs/s25main/Game.cpp
+++ b/libs/s25main/Game.cpp
@@ -178,7 +178,22 @@ void Game::CheckObjective()
             world_.GetGameInterface()->GI_TeamWinner(*bestTeam);
         else
             world_.GetGameInterface()->GI_Winner(bestPlayer);
+
+        if(world_.HasLua() && IsWinnerHuman(bestTeam.value_or(0), bestPlayer))
+            world_.GetLua().EventHumanWinner();
     }
+}
+
+bool Game::IsWinnerHuman(unsigned bestTeam, unsigned bestPlayer) const
+{
+    if(world_.GetPlayer(bestPlayer).isHuman())
+        return true;
+
+    for(auto i = 0u; i < world_.GetNumPlayers(); ++i)
+        if(world_.GetPlayer(bestTeam & (1 << i)).isHuman())
+            return true;
+
+    return false;
 }
 
 AIPlayer* Game::GetAIPlayer(unsigned id)

--- a/libs/s25main/Game.h
+++ b/libs/s25main/Game.h
@@ -38,6 +38,7 @@ private:
     void StatisticStep();
     /// Check if the objective was reached (if set)
     void CheckObjective();
+    bool IsWinnerHuman(unsigned bestTeam, unsigned bestPlayer) const;
 
     bool started_, finished_;
     std::unique_ptr<LuaInterfaceGame> lua;

--- a/libs/s25main/GameManager.cpp
+++ b/libs/s25main/GameManager.cpp
@@ -9,6 +9,7 @@
 #include "RttrConfig.h"
 #include "Settings.h"
 #include "WindowManager.h"
+#include "desktops/dskCampaignVictory.h"
 #include "desktops/dskLobby.h"
 #include "desktops/dskMainMenu.h"
 #include "desktops/dskSplash.h"
@@ -183,6 +184,10 @@ bool GameManager::ShowMenu()
     if(LOBBYCLIENT.IsLoggedIn())
         // Lobby zeigen
         windowManager_.Switch(std::make_unique<dskLobby>());
+    else if(GAMECLIENT.IsCampaignCompleted())
+        WINDOWMANAGER.Switch(std::make_unique<dskCampaignVictory>(0));
+    else if(const auto chapter = GAMECLIENT.GetCampaignChapterCompleted())
+        WINDOWMANAGER.Switch(std::make_unique<dskCampaignVictory>(chapter));
     else
         // Hauptmenü zeigen
         windowManager_.Switch(std::make_unique<dskMainMenu>());

--- a/libs/s25main/Settings.h
+++ b/libs/s25main/Settings.h
@@ -129,11 +129,16 @@ public:
         std::map<unsigned, unsigned> configuration;
     } addons;
 
+    struct
+    {
+        std::map<std::string, std::string> saveData;
+    } campaigns;
+
     static const std::array<short, 13> SCREEN_REFRESH_RATES;
 
 private:
     static const int VERSION;
-    static const std::array<std::string, 10> SECTION_NAMES;
+    static const std::array<std::string, 11> SECTION_NAMES;
 };
 
 #define SETTINGS Settings::inst()

--- a/libs/s25main/desktops/dskCampaignMissionMapSelection.cpp
+++ b/libs/s25main/desktops/dskCampaignMissionMapSelection.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "dskCampaignMissionMapSelection.h"
+#include "CampaignSaveData.h"
 #include "Loader.h"
 #include "WindowManager.h"
 #include "controls/ctrlMapSelection.h"
@@ -45,9 +46,8 @@ dskCampaignMissionMapSelection::dskCampaignMissionMapSelection(CreateServerInfo 
 
     if(settings_->selectionMapData.has_value())
     {
-        auto* mapSelection =
-          AddMapSelection(ID_MapSelection, DrawPoint(0, 0), Extent(800, 508), settings_->selectionMapData.value());
-        mapSelection->setMissionsStatus(std::vector<MissionStatus>(settings_->getNumMaps(), {true, true}));
+        AddMapSelection(ID_MapSelection, DrawPoint(0, 0), Extent(800, 508), settings_->selectionMapData.value())
+          ->setMissionsStatus(getMissionsStatus(*settings_));
     }
 }
 

--- a/libs/s25main/desktops/dskCampaignMissionSelection.cpp
+++ b/libs/s25main/desktops/dskCampaignMissionSelection.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "dskCampaignMissionSelection.h"
+#include "CampaignSaveData.h"
 #include "Loader.h"
 #include "WindowManager.h"
 #include "commonDefines.h"
@@ -114,8 +115,9 @@ void dskCampaignMissionSelection::UpdateMissionPage()
         const libsiedler2::ArchivItem_Map_Header& header =
           checkedCast<const libsiedler2::ArchivItem_Map*>(map[0])->getHeader();
 
-        group->AddTextButton(i, curBtPos, catBtSize, TextureColor::Grey, s25util::ansiToUTF8(header.getName()),
-                             NormalFont);
+        group
+          ->AddTextButton(i, curBtPos, catBtSize, TextureColor::Grey, s25util::ansiToUTF8(header.getName()), NormalFont)
+          ->SetEnabled(isChapterEnabled(*settings_, i));
 
         curBtPos.y += catBtSize.y + distanceBetweenMissionButtonsY;
     }

--- a/libs/s25main/desktops/dskCampaignSelection.cpp
+++ b/libs/s25main/desktops/dskCampaignSelection.cpp
@@ -87,7 +87,8 @@ dskCampaignSelection::dskCampaignSelection(CreateServerInfo csi)
                  Extent(secondColumnExtentX, mutlilineExtentY), TextureColor::Grey, NormalFont);
 
     AddTextButton(ID_Back, DrawPoint(380, 560), Extent(200, 22), TextureColor::Red1, _("Back"), NormalFont);
-    AddTextButton(ID_Next, DrawPoint(590, 560), Extent(200, 22), TextureColor::Green2, _("Continue"), NormalFont);
+    AddTextButton(ID_Next, DrawPoint(590, 560), Extent(200, 22), TextureColor::Green2, _("Continue"), NormalFont)
+      ->SetEnabled(false);
 
     showCampaignInfo(false);
 
@@ -107,7 +108,6 @@ void dskCampaignSelection::Msg_TableSelectItem(const unsigned ctrl_id, const boo
         return;
 
     ctrlButton& btContinue = *GetCtrl<ctrlButton>(ID_Next);
-    btContinue.SetEnabled(false);
     showCampaignInfo(false);
     campaignImage_ = nullptr;
 

--- a/libs/s25main/desktops/dskCampaignVictory.cpp
+++ b/libs/s25main/desktops/dskCampaignVictory.cpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "dskCampaignVictory.h"
+#include "Loader.h"
+#include "WindowManager.h"
+#include "desktops/dskMainMenu.h"
+#include "network/GameClient.h"
+
+dskCampaignVictory::dskCampaignVictory(unsigned char chapter)
+    : Desktop(LOADER.GetImageN(ResourceId{chapter ? "setup896" : "setup895"}, 0))
+{
+    GAMECLIENT.SetCampaignChapterCompleted(0);
+    GAMECLIENT.SetCampaignCompleted(false);
+
+    if(!chapter)
+        return;
+
+    AddText(10, DrawPoint{800 / 2, 600 - 50},
+            _("You have successfully completed chapter") + std::string{" "} + std::to_string(chapter) + ".",
+            COLOR_YELLOW, FontStyle::CENTER, LargeFont);
+}
+
+bool dskCampaignVictory::Msg_LeftDown(const MouseCoords&)
+{
+    return ShowMenu();
+}
+
+bool dskCampaignVictory::Msg_KeyDown(const KeyEvent&)
+{
+    return ShowMenu();
+}
+
+bool dskCampaignVictory::ShowMenu()
+{
+    WINDOWMANAGER.Switch(std::make_unique<dskMainMenu>());
+    return true;
+}

--- a/libs/s25main/desktops/dskCampaignVictory.h
+++ b/libs/s25main/desktops/dskCampaignVictory.h
@@ -1,0 +1,21 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "Desktop.h"
+
+class MouseCoords;
+
+class dskCampaignVictory : public Desktop
+{
+public:
+    dskCampaignVictory(unsigned char chapter);
+
+private:
+    bool Msg_LeftDown(const MouseCoords&) override;
+    bool Msg_KeyDown(const KeyEvent&) override;
+
+    bool ShowMenu();
+};

--- a/libs/s25main/lua/LuaInterfaceGame.cpp
+++ b/libs/s25main/lua/LuaInterfaceGame.cpp
@@ -5,6 +5,7 @@
 #include "LuaInterfaceGame.h"
 #include "EventManager.h"
 #include "Game.h"
+#include "Settings.h"
 #include "WindowManager.h"
 #include "ai/AIInterface.h"
 #include "ai/AIPlayer.h"
@@ -12,9 +13,11 @@
 #include "lua/LuaHelpers.h"
 #include "lua/LuaPlayer.h"
 #include "lua/LuaWorld.h"
+#include "network/GameClient.h"
 #include "postSystem/PostMsg.h"
 #include "world/GameWorld.h"
 #include "gameTypes/Resource.h"
+#include "gameData/CampaignSaveCodes.h"
 #include "s25util/Serializer.h"
 #include "s25util/strAlgos.h"
 
@@ -188,23 +191,26 @@ KAGUYA_MEMBER_FUNCTION_OVERLOADS(SetMissionGoalWrapper, LuaInterfaceGame, SetMis
 
 void LuaInterfaceGame::Register(kaguya::State& state)
 {
-    state["RTTRGame"].setClass(kaguya::UserdataMetatable<LuaInterfaceGame, LuaInterfaceGameBase>()
-                                 .addFunction("ClearResources", &LuaInterfaceGame::ClearResources)
-                                 .addFunction("GetGF", &LuaInterfaceGame::GetGF)
-                                 .addFunction("FormatNumGFs", &LuaInterfaceGame::FormatNumGFs)
-                                 .addFunction("GetGameFrame", &LuaInterfaceGame::GetGF)
-                                 .addFunction("GetNumPlayers", &LuaInterfaceGame::GetNumPlayers)
-                                 .addFunction("Chat", &LuaInterfaceGame::Chat)
-                                 .addOverloadedFunctions("MissionStatement", &LuaInterfaceGame::MissionStatement,
-                                                         &LuaInterfaceGame::MissionStatement2,
-                                                         &LuaInterfaceGame::MissionStatement3)
-                                 .addFunction("SetMissionGoal", SetMissionGoalWrapper())
-                                 .addFunction("PostMessage", &LuaInterfaceGame::PostMessageLua)
-                                 .addFunction("PostMessageWithLocation", &LuaInterfaceGame::PostMessageWithLocation)
-                                 .addFunction("GetPlayer", &LuaInterfaceGame::GetPlayer)
-                                 .addFunction("GetWorld", &LuaInterfaceGame::GetWorld)
-                                 // Old name
-                                 .addFunction("GetPlayerCount", &LuaInterfaceGame::GetNumPlayers));
+    state["RTTRGame"].setClass(
+      kaguya::UserdataMetatable<LuaInterfaceGame, LuaInterfaceGameBase>()
+        .addFunction("ClearResources", &LuaInterfaceGame::ClearResources)
+        .addFunction("GetGF", &LuaInterfaceGame::GetGF)
+        .addFunction("FormatNumGFs", &LuaInterfaceGame::FormatNumGFs)
+        .addFunction("GetGameFrame", &LuaInterfaceGame::GetGF)
+        .addFunction("GetNumPlayers", &LuaInterfaceGame::GetNumPlayers)
+        .addFunction("Chat", &LuaInterfaceGame::Chat)
+        .addOverloadedFunctions("MissionStatement", &LuaInterfaceGame::MissionStatement,
+                                &LuaInterfaceGame::MissionStatement2, &LuaInterfaceGame::MissionStatement3)
+        .addFunction("SetMissionGoal", SetMissionGoalWrapper())
+        .addFunction("PostMessage", &LuaInterfaceGame::PostMessageLua)
+        .addFunction("PostMessageWithLocation", &LuaInterfaceGame::PostMessageWithLocation)
+        .addFunction("EnableCampaignChapter", &LuaInterfaceGame::EnableCampaignChapter)
+        .addFunction("SetCampaignChapterCompleted", &LuaInterfaceGame::SetCampaignChapterCompleted)
+        .addFunction("SetCampaignCompleted", &LuaInterfaceGame::SetCampaignCompleted)
+        .addFunction("GetPlayer", &LuaInterfaceGame::GetPlayer)
+        .addFunction("GetWorld", &LuaInterfaceGame::GetWorld)
+        // Old name
+        .addFunction("GetPlayerCount", &LuaInterfaceGame::GetNumPlayers));
     state["RTTR_Serializer"].setClass(kaguya::UserdataMetatable<Serializer>()
                                         .addFunction("PushInt", &Serializer::PushSignedInt)
                                         .addFunction("PopInt", &Serializer::PopSignedInt)
@@ -313,6 +319,37 @@ void LuaInterfaceGame::PostMessageWithLocation(int playerIdx, const std::string&
                                                       gw.MakeMapPoint(Position(x, y))));
 }
 
+namespace {
+void MarkCampaignChapter(const std::string& campaignUid, unsigned char chapter, char code)
+{
+    if(chapter < 1)
+        return;
+
+    auto& saveData = SETTINGS.campaigns.saveData[campaignUid];
+
+    if(saveData.length() < chapter)
+        saveData.resize(chapter);
+
+    saveData[chapter - 1] = code;
+}
+} // namespace
+
+void LuaInterfaceGame::EnableCampaignChapter(const std::string& campaignUid, unsigned char chapter)
+{
+    MarkCampaignChapter(campaignUid, chapter, CampaignSaveCodes::chapterEnabled);
+}
+
+void LuaInterfaceGame::SetCampaignChapterCompleted(const std::string& campaignUid, unsigned char chapter)
+{
+    MarkCampaignChapter(campaignUid, chapter, CampaignSaveCodes::chapterCompleted);
+    GAMECLIENT.SetCampaignChapterCompleted(chapter);
+}
+
+void LuaInterfaceGame::SetCampaignCompleted(const std::string& /* campaignUid */)
+{
+    GAMECLIENT.SetCampaignCompleted(true);
+}
+
 LuaPlayer LuaInterfaceGame::GetPlayer(int playerIdx)
 {
     lua::assertTrue(playerIdx >= 0 && static_cast<unsigned>(playerIdx) < gw.GetNumPlayers(), "Invalid player idx");
@@ -361,6 +398,13 @@ void LuaInterfaceGame::EventStart(bool isFirstStart)
     kaguya::LuaRef onStart = lua["onStart"];
     if(onStart.type() == LUA_TFUNCTION)
         onStart.call<void>(isFirstStart);
+}
+
+void LuaInterfaceGame::EventHumanWinner()
+{
+    kaguya::LuaRef onStart = lua["onHumanWinner"];
+    if(onStart.type() == LUA_TFUNCTION)
+        onStart.call<void>();
 }
 
 void LuaInterfaceGame::EventGameFrame(unsigned nr)

--- a/libs/s25main/lua/LuaInterfaceGame.h
+++ b/libs/s25main/lua/LuaInterfaceGame.h
@@ -33,6 +33,7 @@ public:
     void EventOccupied(unsigned player, MapPoint pt);
     void EventAttack(unsigned char attackerPlayerId, unsigned char defenderPlayerId, unsigned attackerCount);
     void EventStart(bool isFirstStart);
+    void EventHumanWinner();
     void EventGameFrame(unsigned nr);
     void EventResourceFound(unsigned char player, MapPoint pt, ResourceType type, unsigned char quantity);
     // Called if player wants to cancel a pact
@@ -45,6 +46,7 @@ public:
     // called if pact was created
     void EventPactCreated(PactType pt, unsigned char suggestedByPlayerId, unsigned char targetPlayerId,
                           unsigned duration);
+
     // Callable from Lua
     void ClearResources();
     unsigned GetGF() const;
@@ -58,6 +60,10 @@ public:
     void SetMissionGoal(int playerIdx, const std::string& newGoal = "");
     void PostMessageLua(int playerIdx, const std::string& msg);
     void PostMessageWithLocation(int playerIdx, const std::string& msg, int x, int y);
+
+    void EnableCampaignChapter(const std::string& campaignUid, unsigned char chapter);
+    void SetCampaignChapterCompleted(const std::string& campaignUid, unsigned char chapter);
+    void SetCampaignCompleted(const std::string& campaignUid);
 
 private:
     ILocalGameState& localGameState;

--- a/libs/s25main/network/GameClient.h
+++ b/libs/s25main/network/GameClient.h
@@ -102,6 +102,11 @@ public:
     /// Beendet das Spiel, zerstört die Spielstrukturen
     void ExitGame();
 
+    void SetCampaignChapterCompleted(unsigned char chapter) { chapterCompleted = chapter; }
+    void SetCampaignCompleted(bool state) { campaignCompleted = state; }
+    unsigned char GetCampaignChapterCompleted() const { return chapterCompleted; }
+    bool IsCampaignCompleted() const { return campaignCompleted; }
+
     ClientState GetState() const { return state; }
     Replay* GetReplay();
     std::shared_ptr<const NWFInfo> GetNWFInfo() const;
@@ -307,6 +312,9 @@ private:
 
     /// GameCommands, die vom Client noch an den Server gesendet werden müssen
     std::vector<gc::GameCommandPtr> gameCommands_;
+
+    unsigned char chapterCompleted = 0;
+    bool campaignCompleted = false;
 
     std::unique_ptr<ReplayInfo> replayinfo;
     bool replayMode;

--- a/tests/s25Main/campaign/testCampaignLuaFile.cpp
+++ b/tests/s25Main/campaign/testCampaignLuaFile.cpp
@@ -29,6 +29,7 @@ BOOST_AUTO_TEST_CASE(ScriptVersion)
 
         file << "campaign ={\
                 version = \"1\",\
+                uid = \"roman\",\
                 author = \"Max Meier\",\
                 name = \"Meine Kampagne\",\
                 shortDescription = \"Sehr kurze Beschreibung\",\
@@ -114,6 +115,7 @@ BOOST_AUTO_TEST_CASE(LoadCampaignDescriptionWithoutTranslation)
 
         file << "campaign ={\
             version = \"1\",\
+            uid = \"roman\",\
             author = \"Max Meier\",\
             name = \"Meine Kampagne\",\
             shortDescription = \"Sehr kurze Beschreibung\",\
@@ -123,7 +125,8 @@ BOOST_AUTO_TEST_CASE(LoadCampaignDescriptionWithoutTranslation)
             difficulty = \"easy\",\
             mapFolder = \"<RTTR_GAME>/DATA/MAPS\",\
             luaFolder = \"<RTTR_GAME>/CAMPAIGNS/ROMAN\",\
-            maps = { \"dessert0.WLD\", \"dessert1.WLD\", \"dessert2.WLD\"}\
+            maps = { \"dessert0.WLD\", \"dessert1.WLD\", \"dessert2.WLD\"},\
+            defaultChaptersEnabled = \"100000000\"\
         }";
 
         file << "function getRequiredLuaVersion() return 1 end";
@@ -135,6 +138,7 @@ BOOST_AUTO_TEST_CASE(LoadCampaignDescriptionWithoutTranslation)
 
     // campaign description
     BOOST_TEST(desc.version == "1");
+    BOOST_TEST(desc.uid == "roman");
     BOOST_TEST(desc.author == "Max Meier");
     BOOST_TEST(desc.name == "Meine Kampagne");
     BOOST_TEST(desc.shortDescription == "Sehr kurze Beschreibung");
@@ -142,6 +146,7 @@ BOOST_AUTO_TEST_CASE(LoadCampaignDescriptionWithoutTranslation)
     BOOST_TEST(desc.image == "<RTTR_GAME>/GFX/PICS/WORLD.LBM");
     BOOST_TEST(desc.maxHumanPlayers == 1u);
     BOOST_TEST(desc.difficulty == "easy");
+    BOOST_TEST(desc.defaultChaptersEnabled == "100000000");
 
     // maps
     BOOST_TEST(desc.getNumMaps() == 3u);
@@ -181,6 +186,7 @@ BOOST_AUTO_TEST_CASE(LoadCampaignDescriptionFailsDueToIncorrectDifficulty)
 
         file << "campaign ={\
             version = \"1\",\
+            uid = \"roman\",\
             author = \"Max Meier\",\
             name = \"Meine Kampagne\",\
             shortDescription = \"Sehr kurze Beschreibung\",\
@@ -211,6 +217,7 @@ BOOST_AUTO_TEST_CASE(LoadCampaignDescriptionFailsDueToMissingField)
 
         file << "campaign ={\
             version = \"1\",\
+            uid = \"roman\",\
             author = \"Max Meier\",\
             name = \"Meine Kampagne\",\
             shortDescription = \"Sehr kurze Beschreibung\",\
@@ -257,6 +264,7 @@ BOOST_AUTO_TEST_CASE(CampaignDescriptionLoadWithTranslation)
 
         file << "campaign = {\
             version = \"1\",\
+            uid = \"roman\",\
             author = \"Max Meier\",\
             name = _\"name\",\
             shortDescription = _\"shortDescription\",\
@@ -280,6 +288,7 @@ BOOST_AUTO_TEST_CASE(CampaignDescriptionLoadWithTranslation)
 
     // campaign description
     BOOST_TEST(desc.version == "1");
+    BOOST_TEST(desc.uid == "roman");
     BOOST_TEST(desc.author == "Max Meier");
     BOOST_TEST(desc.name == "Meine Kampagne");
     BOOST_TEST(desc.shortDescription == "Sehr kurze Beschreibung");
@@ -309,6 +318,7 @@ BOOST_AUTO_TEST_CASE(OptionalSelectionMapLoadTest)
 
         file << "campaign = {\
             version = \"1\",\
+            uid = \"roman\",\
             author = \"Max Meier\",\
             name = \"Meine Kampagne\",\
             shortDescription = \"Sehr kurze Beschreibung\",\
@@ -344,6 +354,7 @@ BOOST_AUTO_TEST_CASE(OptionalSelectionMapLoadTest)
 
     // campaign description
     BOOST_TEST(desc.version == "1");
+    BOOST_TEST(desc.uid == "roman");
     BOOST_TEST(desc.author == "Max Meier");
     BOOST_TEST(desc.name == "Meine Kampagne");
     BOOST_TEST(desc.shortDescription == "Sehr kurze Beschreibung");

--- a/tests/s25Main/campaign/testCampaignSaveData.cpp
+++ b/tests/s25Main/campaign/testCampaignSaveData.cpp
@@ -1,0 +1,102 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "CampaignSaveData.h"
+#include "Settings.h"
+#include "lua/CampaignDataLoader.h"
+#include "gameData/CampaignDescription.h"
+#include "gameData/CampaignSaveCodes.h"
+#include "rttr/test/TmpFolder.hpp"
+#include <boost/nowide/fstream.hpp>
+#include <boost/test/unit_test.hpp>
+
+namespace {
+constexpr auto uid = "uniqueID";
+struct CampaignSaveDataFixture
+{
+    CampaignSaveDataFixture()
+    {
+        desc.uid = uid;
+        saveData.clear();
+    }
+
+    CampaignDescription desc;
+    std::map<std::string, std::string>& saveData = SETTINGS.campaigns.saveData;
+};
+} // namespace
+
+BOOST_FIXTURE_TEST_CASE(isChapterEnabled_ReturnsFalse_WhenChapterIsDisabled, CampaignSaveDataFixture)
+{
+    BOOST_TEST_REQUIRE(isChapterEnabled(desc, 0) == false);
+    BOOST_TEST_REQUIRE(isChapterEnabled(desc, 1) == false);
+    BOOST_TEST_REQUIRE(isChapterEnabled(desc, 2) == false);
+    BOOST_TEST_REQUIRE(isChapterEnabled(desc, 9) == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(isChapterEnabled_ReturnsTrue_WhenChapterIsEnabled, CampaignSaveDataFixture)
+{
+    saveData[uid] = "011";
+    BOOST_TEST_REQUIRE(isChapterEnabled(desc, 0) == false);
+    BOOST_TEST_REQUIRE(isChapterEnabled(desc, 1) == true);
+    BOOST_TEST_REQUIRE(isChapterEnabled(desc, 2) == true);
+    BOOST_TEST_REQUIRE(isChapterEnabled(desc, 9) == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(Chapters0and1AreEnabledByDefault, CampaignSaveDataFixture)
+{
+    saveData[uid] = CampaignSaveCodes::defaultChaptersEnabled;
+    BOOST_TEST_REQUIRE(isChapterEnabled(desc, 0) == true);
+    BOOST_TEST_REQUIRE(isChapterEnabled(desc, 1) == true);
+    BOOST_TEST_REQUIRE(isChapterEnabled(desc, 2) == false);
+    BOOST_TEST_REQUIRE(isChapterEnabled(desc, 9) == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(DefaultChaptersCanBeSetPerCampaign, CampaignSaveDataFixture)
+{
+    desc.defaultChaptersEnabled = "100";
+    BOOST_TEST_REQUIRE(isChapterEnabled(desc, 0) == true);
+    BOOST_TEST_REQUIRE(isChapterEnabled(desc, 1) == false);
+    BOOST_TEST_REQUIRE(isChapterEnabled(desc, 2) == false);
+    BOOST_TEST_REQUIRE(isChapterEnabled(desc, 9) == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(
+  getMissionsStatus_ReturnsPlayableForChaptersWhichAreEnabled_AndConqueredForChaptersWhichAreCompleted,
+  CampaignSaveDataFixture)
+{
+    rttr::test::TmpFolder tmp;
+    {
+        boost::nowide::ofstream file(tmp / "campaign.lua");
+
+        file << "campaign ={\
+            version = \"1\",\
+            uid = \"roman\",\
+            author = \"Max Meier\",\
+            name = \"Meine Kampagne\",\
+            shortDescription = \"Sehr kurze Beschreibung\",\
+            longDescription = \"Das ist die lange Beschreibung\",\
+            image = \"<RTTR_GAME>/GFX/PICS/WORLD.LBM\",\
+            maxHumanPlayers = 1,\
+            difficulty = \"easy\",\
+            mapFolder = \"<RTTR_GAME>/DATA/MAPS\",\
+            luaFolder = \"<RTTR_GAME>/CAMPAIGNS/ROMAN\",\
+            maps = { \"dessert0.WLD\", \"dessert1.WLD\", \"dessert2.WLD\"}\
+        }";
+
+        file << "function getRequiredLuaVersion() return 1 end";
+    }
+
+    CampaignDescription dsc;
+    CampaignDataLoader loader{dsc, tmp};
+    BOOST_TEST_REQUIRE(loader.Load());
+
+    saveData["roman"] = "210";
+    const auto& ms = getMissionsStatus(dsc);
+    BOOST_TEST_REQUIRE(ms[0].playable == true);
+    BOOST_TEST_REQUIRE(ms[0].conquered == true);
+    BOOST_TEST_REQUIRE(ms[1].playable == true);
+    BOOST_TEST_REQUIRE(ms[1].conquered == false);
+    BOOST_TEST_REQUIRE(ms[2].playable == false);
+    BOOST_TEST_REQUIRE(ms[2].conquered == false);
+}

--- a/tests/s25Main/lua/testLua.cpp
+++ b/tests/s25Main/lua/testLua.cpp
@@ -6,6 +6,7 @@
 #include "Loader.h"
 #include "PointOutput.h"
 #include "RttrForeachPt.h"
+#include "Settings.h"
 #include "buildings/noBuildingSite.h"
 #include "buildings/nobHQ.h"
 #include "enum_cast.hpp"
@@ -841,6 +842,20 @@ BOOST_AUTO_TEST_CASE(onExplored)
         std::sort(luaPts.begin(), luaPts.end());
         BOOST_TEST_REQUIRE(luaPts == gamePts, boost::test_tools::per_element());
     }
+}
+
+BOOST_AUTO_TEST_CASE(CampaignStatusCanBeChangedFromLua)
+{
+    initWorld();
+
+    SETTINGS.campaigns.saveData["campaign_id"] = "110";
+    executeLua("rttr:SetCampaignChapterCompleted('campaign_id', 2)");
+    executeLua("rttr:SetCampaignChapterCompleted('campaign_id', 4)");
+    executeLua("rttr:EnableCampaignChapter('campaign_id', 5)");
+    executeLua("rttr:SetCampaignChapterCompleted('campaign_id', 0)"); // noop
+    executeLua("rttr:EnableCampaignChapter('campaign_id', 0)");       // noop
+    game.executeAICommands();
+    BOOST_TEST_REQUIRE(SETTINGS.campaigns.saveData["campaign_id"] == "12021");
 }
 
 BOOST_AUTO_TEST_CASE(LuaPacts)


### PR DESCRIPTION
Added support for Roman-style ([video](https://streamable.com/6zo42j)) campaigns and the world campaign ([video](https://streamable.com/4ojiaj)).

Fixed world campaign scripts to unlock the same continents as it was in S2.