### PR TITLE
Fix map "The snake" and enable overriding crucial map settings from LUA

### DIFF
--- a/data/RTTR/campaigns/roman/MISS200.lua
+++ b/data/RTTR/campaigns/roman/MISS200.lua
@@ -175,6 +175,10 @@ rttr:RegisterTranslations(
     },
 })
 
+function getNumPlayers()
+    return 1
+end
+
 -- format mission texts
 -- BUG:     NewLine at the end is wrongly interpreted, adding 2x Space resolves this issue
 function MissionText(e)
@@ -205,13 +209,6 @@ function onSettingsReady()
 
     rttr:GetPlayer(0):SetNation(NAT_ROMANS)     -- nation
     rttr:GetPlayer(0):SetColor(0)               -- 0:blue, 1:red, 2:yellow, 
-
-    rttr:GetPlayer(1):Close()
-    rttr:GetPlayer(2):Close()
-    rttr:GetPlayer(3):Close()
-    rttr:GetPlayer(4):Close()
-    rttr:GetPlayer(5):Close()
-    rttr:GetPlayer(6):Close()
 end
 
 function getAllowedChanges()

--- a/data/RTTR/campaigns/roman/MISS206.lua
+++ b/data/RTTR/campaigns/roman/MISS206.lua
@@ -218,9 +218,12 @@ function addPlayerBld(p, onLoad)
             nil, nil
         )
 
-        if(p == 2) then
-            if onLoad then return end
+        if onLoad then return end
 
+        if(p == 1) then
+            rttr:GetPlayer(p):PlaceHQ(112, 82)  -- !SET_HOUSE 24, 112, 82
+        elseif(p == 2) then
+            rttr:GetPlayer(p):PlaceHQ(40, 54)   -- !SET_HOUSE 24, 40, 54
             rttr:GetPlayer(p):AIConstructionOrder(43, 59, BLD_FORTRESS)
         end
     end

--- a/libs/s25main/GameLobby.cpp
+++ b/libs/s25main/GameLobby.cpp
@@ -24,3 +24,8 @@ unsigned GameLobby::getNumPlayers() const
 {
     return players_.size();
 }
+
+void GameLobby::setNumPlayers(unsigned num)
+{
+    players_.resize(num);
+}

--- a/libs/s25main/GameLobby.h
+++ b/libs/s25main/GameLobby.h
@@ -21,6 +21,7 @@ public:
     const JoinPlayerInfo& getPlayer(unsigned playerId) const;
     const std::vector<JoinPlayerInfo>& getPlayers() const { return players_; }
     unsigned getNumPlayers() const;
+    void setNumPlayers(unsigned num);
 
     GlobalGameSettings& getSettings() { return ggs_; }
     const GlobalGameSettings& getSettings() const { return ggs_; }

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -13,6 +13,7 @@
 #include "Ware.h"
 #include "addons/const_addons.h"
 #include "buildings/noBuildingSite.h"
+#include "buildings/nobHQ.h"
 #include "buildings/nobHarborBuilding.h"
 #include "buildings/nobMilitary.h"
 #include "buildings/nobUsual.h"
@@ -374,6 +375,19 @@ void GamePlayer::RemoveBuildingSite(noBuildingSite* bldSite)
 {
     RTTR_Assert(bldSite->GetPlayer() == GetPlayerId());
     buildings.Remove(bldSite);
+}
+
+bool GamePlayer::IsHQTent() const
+{
+    if(const nobHQ* hq = GetHQ())
+        return hq->IsTent();
+    return false;
+}
+
+void GamePlayer::SetHQIsTent(bool isTent)
+{
+    if(nobHQ* hq = GetHQ())
+        hq->SetIsTent(isTent);
 }
 
 void GamePlayer::AddBuilding(noBuilding* bld, BuildingType bldType)
@@ -1363,6 +1377,12 @@ void GamePlayer::TestDefeat()
     // Keine Militärgebäude, keine Lagerhäuser (HQ,Häfen) -> kein Land --> verloren
     if(!isDefeated && buildings.GetMilitaryBuildings().empty() && buildings.GetStorehouses().empty())
         Surrender();
+}
+
+nobHQ* GamePlayer::GetHQ() const
+{
+    const MapPoint& hqPos = GetHQPos();
+    return const_cast<nobHQ*>(hqPos.isValid() ? GetGameWorld().GetSpecObj<nobHQ>(hqPos) : nullptr);
 }
 
 void GamePlayer::Surrender()

--- a/libs/s25main/GamePlayer.h
+++ b/libs/s25main/GamePlayer.h
@@ -31,6 +31,7 @@ class noShip;
 class nobBaseMilitary;
 class nobBaseWarehouse;
 class nobHarborBuilding;
+class nobHQ;
 class nobMilitary;
 class nofCarrier;
 class nofFlagWorker;
@@ -91,6 +92,9 @@ public:
     const GameWorld& GetGameWorld() const { return world; }
 
     const MapPoint& GetHQPos() const { return hqPos; }
+    bool IsHQTent() const;
+    void SetHQIsTent(bool isTent);
+
     void AddBuilding(noBuilding* bld, BuildingType bldType);
     void RemoveBuilding(noBuilding* bld, BuildingType bldType);
     void AddBuildingSite(noBuildingSite* bldSite);
@@ -426,6 +430,7 @@ private:
     bool FindWarehouseForJob(Job job, noRoadNode* goal) const;
     /// Prüft, ob der Spieler besiegt wurde
     void TestDefeat();
+    nobHQ* GetHQ() const;
 
     //////////////////////////////////////////////////////////////////////////
     /// Unsynchronized state (e.g. lua, gui...)

--- a/libs/s25main/desktops/dskGameLobby.cpp
+++ b/libs/s25main/desktops/dskGameLobby.cpp
@@ -32,6 +32,7 @@
 #include "ingameWindows/iwMsgbox.h"
 #include "lua/LuaInterfaceSettings.h"
 #include "network/GameClient.h"
+#include "network/GameServer.h"
 #include "ogl/FontStyle.h"
 #include "gameData/GameConsts.h"
 #include "gameData/const_gui_ids.h"
@@ -99,6 +100,13 @@ dskGameLobby::dskGameLobby(ServerType serverType, std::shared_ptr<GameLobby> gam
               gameLobby_->isHost()); // This should be done first for the host so others won't even see the script
             LOG.write(_("Lua was disabled by the script itself\n"));
             lua.reset();
+        } else
+        {
+            if(const auto num = lua->GetNumPlayersFromScript())
+            {
+                GAMESERVER.SetNumPlayers(num);
+                gameLobby_->setNumPlayers(num);
+            }
         }
         if(!lua)
             lobbyHostController->RemoveLuaScript();

--- a/libs/s25main/lua/LuaInterfaceSettings.cpp
+++ b/libs/s25main/lua/LuaInterfaceSettings.cpp
@@ -247,3 +247,13 @@ bool LuaInterfaceSettings::IsMapPreviewEnabled()
     }
     return true;
 }
+
+unsigned LuaInterfaceSettings::GetNumPlayersFromScript()
+{
+    kaguya::LuaRef func = lua["getNumPlayers"];
+    if(func.type() == LUA_TFUNCTION)
+    {
+        return func.call<unsigned>();
+    }
+    return 0;
+}

--- a/libs/s25main/lua/LuaInterfaceSettings.h
+++ b/libs/s25main/lua/LuaInterfaceSettings.h
@@ -36,6 +36,7 @@ public:
     /// Get addons that are allowed to be changed
     std::vector<AddonId> GetAllowedAddons();
     bool IsMapPreviewEnabled();
+    unsigned GetNumPlayersFromScript();
 
 private:
     IGameLobbyController& lobbyServerController_;

--- a/libs/s25main/lua/LuaPlayer.h
+++ b/libs/s25main/lua/LuaPlayer.h
@@ -10,6 +10,7 @@
 #include "gameTypes/BuildingType.h"
 #include "gameTypes/GoodTypes.h"
 #include "gameTypes/JobTypes.h"
+#include "gameTypes/MapCoordinates.h"
 #include "gameTypes/PactTypes.h"
 #include "gameTypes/StatisticTypes.h"
 #include <map>
@@ -50,6 +51,7 @@ public:
     unsigned GetNumPeople(lua::SafeEnum<Job> job) const;
     unsigned GetStatisticsValue(lua::SafeEnum<StatisticType> stat) const;
     bool AIConstructionOrder(unsigned x, unsigned y, lua::SafeEnum<BuildingType> bld);
+    void PlaceHQ(MapCoord x, MapCoord y);
     void ModifyHQ(bool isTent);
     bool IsDefeated() const;
     void Surrender(bool destroyBlds);

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -323,8 +323,8 @@ void GameClient::StartGame(const unsigned random_init)
             gameWorld.GetPlayer(i).MakeStartPacts();
 
         MapLoader loader(gameWorld);
-        if(!loader.Load(mapinfo.filepath)
-           || (!mapinfo.luaFilepath.empty() && !loader.LoadLuaScript(*game, *this, mapinfo.luaFilepath)))
+        if((!mapinfo.luaFilepath.empty() && !loader.LoadLuaScript(*game, *this, mapinfo.luaFilepath))
+           || !loader.Load(mapinfo.filepath)) // do not reorder: load lua first, load map second
         {
             OnError(ClientError::InvalidMap);
             return;

--- a/libs/s25main/network/GameServer.cpp
+++ b/libs/s25main/network/GameServer.cpp
@@ -526,6 +526,11 @@ bool GameServer::assignPlayersOfRandomTeams(std::vector<JoinPlayerInfo>& playerI
     return playerWasAssigned;
 }
 
+void GameServer::SetNumPlayers(unsigned num)
+{
+    playerInfos.resize(num);
+}
+
 /**
  *  startet das Spiel.
  */

--- a/libs/s25main/network/GameServer.h
+++ b/libs/s25main/network/GameServer.h
@@ -52,6 +52,8 @@ public:
     /// Assign players that do not have a fixed team, return true if any player was assigned.
     static bool assignPlayersOfRandomTeams(std::vector<JoinPlayerInfo>& playerInfos);
 
+    void SetNumPlayers(unsigned num);
+
 private:
     bool StartGame();
 

--- a/libs/s25main/world/MapLoader.cpp
+++ b/libs/s25main/world/MapLoader.cpp
@@ -421,8 +421,11 @@ bool MapLoader::PlaceHQs(GameWorldBase& world, std::vector<MapPoint> hqPositions
         // Does the HQ have a position?
         if(i >= hqPositions.size() || !hqPositions[i].isValid())
         {
-            LOG.write(_("Player %u does not have a valid start position!")) % i;
-            return false;
+            LOG.write(_("Player %u does not have a valid start position!\n")) % i;
+            if(world.HasLua()) // maybe the HQ is placed in the script?
+                continue;
+            else
+                return false;
         }
 
         BuildingFactory::CreateBuilding(world, BuildingType::Headquarters, hqPositions[i], i,

--- a/tests/s25Main/integration/testGamePlayer.cpp
+++ b/tests/s25Main/integration/testGamePlayer.cpp
@@ -119,3 +119,28 @@ BOOST_FIXTURE_TEST_CASE(ProductivityStats, WorldFixtureEmpty1P)
     BOOST_TEST(buildingRegister.CalcProductivities() == expectedProductivity, per_element());
     BOOST_TEST(buildingRegister.CalcAverageProductivity() == avgProd);
 }
+
+BOOST_FIXTURE_TEST_CASE(IsHQTent_ReturnsFalse_IfPrimaryHQIsNotTent, WorldFixtureEmpty1P)
+{
+    GamePlayer& p1 = world.GetPlayer(0);
+
+    // place another HQ that is a tent
+    MapPoint newHqPos = p1.GetHQPos();
+    newHqPos.x += 3;
+    BuildingFactory::CreateBuilding(world, BuildingType::Headquarters, newHqPos, 0, Nation::Babylonians, true);
+
+    BOOST_TEST_REQUIRE(p1.IsHQTent() == false);
+}
+
+BOOST_FIXTURE_TEST_CASE(IsHQTent_ReturnsTrue_IfPrimaryHQIsTent, WorldFixtureEmpty1P)
+{
+    GamePlayer& p1 = world.GetPlayer(0);
+    p1.SetHQIsTent(true);
+
+    // place another HQ that is not a tent
+    MapPoint newHqPos = p1.GetHQPos();
+    newHqPos.x += 3;
+    BuildingFactory::CreateBuilding(world, BuildingType::Headquarters, newHqPos, 0, Nation::Babylonians, false);
+
+    BOOST_TEST_REQUIRE(p1.IsHQTent() == true);
+}


### PR DESCRIPTION
Fixes map "The snake" WITHOUT changing the map. You can now use the original S2 map, but I needed to implement some additional features, like placing HQs scripts and overriding the number of players from LUA scripts. For example Roman chapter 1 does not show 7 players anymore and chapter 7 has the player 3 HQ set from LUA ([video](https://streamable.com/1m826i)). This also provides makes it possible to fix all other maps where the positions are not set in the map but only in RTX files (like half the FANpaign maps - [example video](https://streamable.com/9m3a82)).