### PR TITLE
Add SetComputerBarrier

### DIFF
--- a/data/RTTR/campaigns/roman/MISS202.lua
+++ b/data/RTTR/campaigns/roman/MISS202.lua
@@ -30,7 +30,7 @@ function checkVersion()
 end
 -------------------------------- mission events and texts ---------------------
 -- Message-Window (mission statement and hints): 52 chars wide
-eIdx = {1, 2, 3, 98, 99}
+eIdx = {1, 2, 3, 99}
 
 rttr:RegisterTranslations(
 {
@@ -163,6 +163,9 @@ function onStart(isFirstStart)
         MissionEvent(1)                     -- initial event / start screen
     end
 
+    rttr:GetWorld():SetComputerBarrier(6, 70, 71)
+    rttr:GetWorld():SetComputerBarrier(6, 59, 60)
+
     if isFirstStart then
         -- type 8 == 7 in rttr
         rttr:GetWorld():AddAnimal( 70,  72, SPEC_DUCK)
@@ -239,26 +242,6 @@ function addPlayerBld(p, onLoad)
 
     if(p == 0) then
         rttr:GetPlayer(p):DisableBuilding(BLD_LOOKOUTTOWER, false)
-
-    else
-        rttr:GetPlayer(p):SetRestrictedArea(
-            nil, nil,       -- enable the whole map
-                0,   0,
-                0,   127,
-                127, 127,
-                127, 0,
-            nil, nil,       -- R=6, X=70, Y=71 V R=6, X=59, Y=60
-                73,  65,
-                76,  71,
-                73,  77,
-                67,  77,
-                56,  66,
-                53,  60,
-                56,  54,
-                62,  54,
-                73,  65,
-            nil, nil
-        )
     end
 end
 
@@ -492,10 +475,6 @@ function onOccupied(p, x, y)
 
     if( (x == 89) and (y == 20) ) then MissionEvent(99)
     end
-
-    if(not rttr:GetPlayer(1):IsInRestrictedArea(x, y)) then 
-        MissionEvent(98) -- for lifting restrictions
-    end
 end
 
 function onExplored(p, x, y, o)
@@ -515,10 +494,6 @@ function MissionEvent(e, onLoad)
     -- call side effects for active events, check "eState[e] == 1" for multiple call events!
     if(e == 2) then
         rttr:GetPlayer(0):EnableBuilding(BLD_LOOKOUTTOWER, not onLoad)
-        
-    elseif(e == 98) then
-        rttr:GetPlayer(1):SetRestrictedArea()
-        rttr:GetPlayer(2):SetRestrictedArea()
 
     elseif(e == 99) then
         -- TODO: EnableNextMissions()

--- a/data/RTTR/campaigns/roman/MISS203.lua
+++ b/data/RTTR/campaigns/roman/MISS203.lua
@@ -30,7 +30,7 @@ function checkVersion()
 end
 -------------------------------- mission events and texts ---------------------
 -- Message-Window (mission statement and hints): 52 chars wide
-eIdx = {1, 2, 3, 98, 99}
+eIdx = {1, 2, 3, 99}
 
 rttr:RegisterTranslations(
 {
@@ -161,7 +161,12 @@ function onStart(isFirstStart)
         eHist = {["n"] = 0}
         MissionEvent(1)                     -- initial event / start screen
     end
-    
+
+    rttr:GetWorld():SetComputerBarrier(14, 61, 75)
+    rttr:GetWorld():SetComputerBarrier(13, 62, 92)
+    rttr:GetWorld():SetComputerBarrier(12, 77, 37)
+    rttr:GetWorld():SetComputerBarrier(12, 79, 24)
+
     if isFirstStart then
         -- type 8 == 7 in rttr
         rttr:GetWorld():AddAnimal(  8,  17, SPEC_POLARBEAR)
@@ -213,39 +218,6 @@ function addPlayerBld(p, onLoad)
     rttr:GetPlayer(p):EnableAllBuildings()
     rttr:GetPlayer(p):DisableBuilding(BLD_SHIPYARD, false)
     rttr:GetPlayer(p):DisableBuilding(BLD_HARBORBUILDING, false)
-
-    if not (p == 0) then
-        -- set restriction area for all AIs
-        rttr:GetPlayer(p):SetRestrictedArea(
-            nil, nil,           -- enable the whole map
-                  0,   0,
-                  0, 127,
-                127, 127,
-                127,   0,
-            nil, nil,           -- R=12, X=77, Y=37 V   R=12->8, X=79, Y=24
-                 83,  16,
-                 87,  24,
-                 89,  37,
-                 83,  49,
-                 71,  49,
-                 65,  37,
-                 71,  24,
-                 83,  16,
-            nil, nil,           -- R=14, X=61, Y=75 V   R=13, X=62, Y=92
-                 68,  61,
-                 75,  75,
-                 68,  79,
-                 75,  92,
-                 68, 105,
-                 55, 105,
-                 49,  92,
-                 54,  89,
-                 47,  75,
-                 54,  61,
-                 68,  61,
-            nil, nil
-        )
-    end
 end
 
 -------------------------------- set resources --------------------------------
@@ -480,10 +452,6 @@ function onOccupied(p, x, y)
     if(     (x == 10) and (y == 37) ) then MissionEvent(2)
     elseif( (x == 97) and (y == 68) ) then MissionEvent(99)
     end
-
-    if(not rttr:GetPlayer(1):IsInRestrictedArea(x, y)) then 
-        MissionEvent(98) -- for lifting restrictions
-    end
 end
 
 function onExplored(p, x, y)
@@ -507,10 +475,6 @@ function MissionEvent(e, onLoad)
     if(e == 2) then
         rttr:GetPlayer(0):EnableBuilding(BLD_HARBORBUILDING, not onLoad)
         rttr:GetPlayer(0):EnableBuilding(BLD_SHIPYARD, not onLoad)
-
-    elseif(e == 98) then
-        rttr:GetPlayer(1):SetRestrictedArea()
-        rttr:GetPlayer(2):SetRestrictedArea()
 
     elseif(e == 99) then
         -- TODO: EnableNextMissions()

--- a/data/RTTR/campaigns/roman/MISS205.lua
+++ b/data/RTTR/campaigns/roman/MISS205.lua
@@ -30,7 +30,7 @@ function checkVersion()
 end
 -------------------------------- mission events and texts --------------------
 -- Message-Window (mission statement and hints): 52 chars wide
-eIdx = {1, 2, 3, 98, 99}
+eIdx = {1, 2, 3, 99}
 
 rttr:RegisterTranslations(
 {
@@ -156,6 +156,18 @@ function onStart(isFirstStart)
         MissionEvent(1)                     -- initial event / start screen
     end
 
+    rttr:GetWorld():SetComputerBarrier(16, 162, 69)
+    rttr:GetWorld():SetComputerBarrier(17, 148, 107)
+    rttr:GetWorld():SetComputerBarrier(15, 131, 71)
+    rttr:GetWorld():SetComputerBarrier(16, 103, 40)
+    rttr:GetWorld():SetComputerBarrier(13, 124, 93)
+    rttr:GetWorld():SetComputerBarrier(13, 103, 49)
+    rttr:GetWorld():SetComputerBarrier(12, 108, 66)
+    rttr:GetWorld():SetComputerBarrier(14, 61, 111)
+    rttr:GetWorld():SetComputerBarrier(13, 48, 41)
+    rttr:GetWorld():SetComputerBarrier(14, 40, 52)
+    rttr:GetWorld():SetComputerBarrier(14, 25, 45)
+
     if isFirstStart then
         -- type 8 == 7 in rttr
         rttr:GetWorld():AddAnimal( 126,  48, SPEC_DUCK)
@@ -228,77 +240,6 @@ end
 function addPlayerBld(p, onLoad)
     -- set buildings for all players
     rttr:GetPlayer(p):EnableAllBuildings()
-
-    if not (p == 0) then
-        rttr:GetPlayer(p):SetRestrictedArea(
-            nil, nil,       -- enable the whole map
-                0,   0,
-                0, 127,
-                191, 127,
-                191,   0,
-            nil, nil,       -- R=16,    X=162,  Y=69    (Choose R=10 -> Yellow can conquer mountain)
-                167,  59,
-                172,  69,
-                167,  79,
-                157,  79,
-                152,  69,
-                157,  59,
-                167,  59,
-            nil, nil,       -- R=17,    X=148,  Y=107
-                157,  90,
-                165, 107,
-                157, 124,
-                140, 124,
-                131, 107,
-                140,  90,
-                157,  90,
-            nil, nil,       -- R=15,    X=131,  Y=71    (Choose R=4 -> Yellow HQ!)
-                133,  67,
-                135,  71,
-                133,  75,
-                129,  75,
-                127,  71,
-                129,  67,
-                133,  67,
-            nil, nil,       -- R=16,    X=103,  Y=40    V
-                87,  40,    -- R=13,    X=103,  Y=49    V
-                95,  24,    -- R=12,    X=108,  Y=66
-                111,  24,
-                119,  40,
-                116,  49,
-                120,  66,
-                114,  78,
-                102,  78,
-                96,  66,
-                90,  49,
-                87,  40,
-            nil, nil,       -- R=13,    X=124,  Y=93
-                131,  80,
-                137,  93,
-                131, 106,
-                118, 106,
-                111,  93,
-                118,  80,
-                131,  80,
-            nil, nil,       -- R=14,    X=61,   Y=111
-                68,  97,
-                75, 111,
-                68, 125,
-                54, 125,
-                47, 111,
-                54,  97,
-                68,  97,
-            nil, nil,       -- R=13,    X=48,   Y=41
-                55,  28,
-                61,  41,
-                55,  54,
-                42,  54,
-                35,  41,
-                42,  28,
-                55,  28,
-            nil, nil        -- ignore R=14, X=40, Y=52 and R=14, X=25, Y=45
-        )
-    end
 end
 
 -------------------------------- set resources --------------------------------
@@ -533,10 +474,6 @@ function onOccupied(p, x, y)
     if(     (x == 102) and (y == 50) ) then MissionEvent(3)
     elseif( (x == 148) and (y == 50) ) then MissionEvent(99)
     end
-    
-    if(not rttr:GetPlayer(1):IsInRestrictedArea(x, y)) then 
-        MissionEvent(98) -- for lifting restrictions
-    end
 end
 
 function onExplored(p, x, y, o)
@@ -551,14 +488,9 @@ function MissionEvent(e, onLoad)
     if(eState[e] <= 0) then
         return
     end
-
-    if(e == 98) then
-        rttr:Log("liftRestrictions")
-        rttr:GetPlayer(1):SetRestrictedArea()
-        rttr:GetPlayer(2):SetRestrictedArea()
     
     -- call side effects for active events, check "eState[e] == 1" for multiple call events!
-    elseif(e == 99) then
+    if(e == 99) then
         -- TODO: EnableNextMissions()
         -- Show opened arc
         rttr:GetWorld():AddStaticObject(148, 50, 561, 0xFFFF, 2)

--- a/data/RTTR/campaigns/roman/MISS206.lua
+++ b/data/RTTR/campaigns/roman/MISS206.lua
@@ -30,7 +30,7 @@ function checkVersion()
 end
 -------------------------------- mission events and texts --------------------
 -- Message-Window (mission statement and hints): 52 chars wide
-eIdx = {1, 2, 3, 98, 99}
+eIdx = {1, 2, 3, 99}
 
 rttr:RegisterTranslations(
 {
@@ -155,6 +155,12 @@ function onStart(isFirstStart)
         eHist = {["n"] = 0}
         MissionEvent(1)                         -- initial event / start screen
     end
+
+    rttr:GetWorld():SetComputerBarrier(10, 51, 22)
+    rttr:GetWorld():SetComputerBarrier(10, 36, 23)
+    rttr:GetWorld():SetComputerBarrier(8, 50, 60)
+    rttr:GetWorld():SetComputerBarrier(8, 49, 64)
+    rttr:GetWorld():SetComputerBarrier(8, 47, 68)
 end
 
 -- save callback
@@ -183,46 +189,9 @@ function addPlayerBld(p, onLoad)
     rttr:GetPlayer(p):DisableBuilding(BLD_SHIPYARD, false)
     rttr:GetPlayer(p):DisableBuilding(BLD_HARBORBUILDING, false)
 
-    --!GLOBAL_SET_COMPUTER_BARRIER     10     51  22
-    --!GLOBAL_SET_COMPUTER_BARRIER     10     36  23
-    --!GLOBAL_SET_COMPUTER_BARRIER     08     50  60
-    --!GLOBAL_SET_COMPUTER_BARRIER     08     49  64
-    --!GLOBAL_SET_COMPUTER_BARRIER     08     47  68
-
-    if not(p == 0) then
-        rttr:GetPlayer(p):SetRestrictedArea(
-            nil, nil,       -- enable the whole map
-                  0,   0,
-                  0, 127,
-                143, 127,
-                143,   0,
-            nil, nil,       -- R=10,    X=51,   Y=22    V 
-                56,  13,   -- R=10,    X=36,   Y=23
-                61,  23,
-                56,  33,
-                48,  32,
-                50,  26,
-                26,  23,
-                31,  13,
-                56,  13,
-            nil, nil,       -- R=08,    X=50,   Y=60    V   (->     R=6,    X=52,   Y=60)
-                46,  60,    -- R=08,    X=49,   Y=64    V
-                49,  54,    -- R=08,    X=47,   Y=68        (->     R=6,    X=47,   Y=68)
-                55,  54,
-                58,  60,
-                53,  68,
-                50,  74,
-                44,  74,
-                41,  68,
-                46,  60,
-            nil, nil
-        )
-
-        if(p == 2) then
-            if onLoad then return end
-
-            rttr:GetPlayer(p):AIConstructionOrder(43, 59, BLD_FORTRESS)
-        end
+    if(p == 2) then
+        if onLoad then return end
+        rttr:GetPlayer(p):AIConstructionOrder(43, 59, BLD_FORTRESS)
     end
 end
 
@@ -457,10 +426,6 @@ function onOccupied(p, x, y)
 
     if( (x == 13) and (y == 66) ) then MissionEvent(99)
     end
-
-    if(not rttr:GetPlayer(1):IsInRestrictedArea(x, y)) then 
-        MissionEvent(98) -- for lifting restrictions
-    end
 end
 
 function onExplored(p, x, y, o)
@@ -484,12 +449,8 @@ function MissionEvent(e, onLoad)
         return
     end
 
-    if(e == 98) then
-        rttr:GetPlayer(1):SetRestrictedArea()
-        rttr:GetPlayer(2):SetRestrictedArea()
-
     -- call side effects for active events, check "eState[e] == 1" for multiple call events!
-    elseif(e == 99) then
+    if(e == 99) then
         -- TODO: EnableNextMissions()
         -- Show opened arc
         rttr:GetWorld():AddStaticObject(13, 66, 561, 0xFFFF, 2)

--- a/data/RTTR/campaigns/roman/MISS207.lua
+++ b/data/RTTR/campaigns/roman/MISS207.lua
@@ -30,7 +30,7 @@ function checkVersion()
 end
 -------------------------------- mission events and texts --------------------
 -- Message-Window (mission statement and hints): 52 chars wide
-eIdx = {1, 98, 99}
+eIdx = {1, 99}
 
 rttr:RegisterTranslations(
 {
@@ -131,6 +131,11 @@ function onStart(isFirstStart)
         eHist = {["n"] = 0}
         MissionEvent(1)                         -- initial event / start screen
     end
+
+    rttr:GetWorld():SetComputerBarrier(10, 41, 122)
+    rttr:GetWorld():SetComputerBarrier(10, 72, 111)
+    rttr:GetWorld():SetComputerBarrier(15, 72, 97)
+    rttr:GetWorld():SetComputerBarrier(10, 19, 100)
 end
 
 function getAllowedChanges()
@@ -172,23 +177,7 @@ function addPlayerBld(p, onLoad)
     if not(p == 0) then
         rttr:GetPlayer(p):DisableBuilding(BLD_SHIPYARD, false)
         rttr:GetPlayer(p):DisableBuilding(BLD_HARBORBUILDING, false)
-        rttr:GetPlayer(p):SetRestrictedArea(
-            nil, nil,       -- enable the whole map
-                0,   0,
-                0, 143,
-                143, 143,
-                143,   0,
-            nil, nil,       -- R=15,    X=72,   Y=97    (change R -> 10, HQ!)
-                77,  87,
-                82,  97,
-                77, 107,
-                67, 107,
-                62,  97,
-                67,  87,
-                77,  87,
-            nil, nil        -- ignore   R=10,   X=41,   Y=122
-        )                   --          R=10,   X=72,   Y=111
-    end                     --          R=10,   X=19,   Y=100
+    end
 end
 
 -------------------------------- set resources --------------------------------
@@ -422,10 +411,6 @@ function onOccupied(p, x, y)
 
     if( (x == 11) and (y == 125) ) then MissionEvent(99)
     end
-    
-    if(not rttr:GetPlayer(1):IsInRestrictedArea(x, y)) then 
-        MissionEvent(98) -- for lifting restrictions
-    end
 end
 
 -- execute mission events, e == 1 is initial event, e == 99 is final event
@@ -436,11 +421,7 @@ function MissionEvent(e, onLoad)
     end
 
     -- call side effects for active events, check "eState[e] == 1" for multiple call events!
-    if(e == 98) then
-        rttr:GetPlayer(1):SetRestrictedArea()
-        rttr:GetPlayer(2):SetRestrictedArea()
-
-    elseif(e == 99) then
+    if(e == 99) then
         -- TODO: EnableNextMissions()
         -- Show opened arc
         rttr:GetWorld():AddStaticObject(11, 125, 561, 0xFFFF, 2)

--- a/data/RTTR/campaigns/roman/MISS208.lua
+++ b/data/RTTR/campaigns/roman/MISS208.lua
@@ -30,7 +30,7 @@ function checkVersion()
 end
 -------------------------------- mission events and texts ---------------------
 -- Message-Window (mission statement and hints): 52 chars wide
-eIdx = {1, 98, 99}
+eIdx = {1, 99}
 
 rttr:RegisterTranslations(
 {
@@ -131,6 +131,9 @@ function onStart(isFirstStart)
         eHist = {["n"] = 0}
         MissionEvent(1)                         -- initial event / start screen
     end
+
+    rttr:GetWorld():SetComputerBarrier(12, 112, 85)
+    rttr:GetWorld():SetComputerBarrier(12, 103, 29)
 end
 
 function getAllowedChanges()
@@ -171,23 +174,6 @@ function addPlayerBld(p, onLoad)
     if not(p == 0) then
         rttr:GetPlayer(p):DisableBuilding(BLD_SHIPYARD)
         rttr:GetPlayer(p):DisableBuilding(BLD_HARBORBUILDING)
-        rttr:GetPlayer(p):SetRestrictedArea(
-            nil, nil,           -- enable the whole map
-                0,   0,
-                0, 111,
-                159, 111,
-                159,   0,
-            nil, nil,
-                -- ignore old restrictions R=12,	X=112,	Y=85
-                118, 97,
-                106, 97,
-                100, 85,
-                106, 73,
-                109, 69,
-                121, 90,
-                118, 97,
-            nil,nil
-        )
     end
 end
 
@@ -422,10 +408,6 @@ function onOccupied(p, x, y)
 
     if( (x == 127) and (y == 48) ) then MissionEvent(99)
     end
-
-    if(not rttr:GetPlayer(1):IsInRestrictedArea(x, y)) then 
-        MissionEvent(98) -- for lifting restrictions
-    end
 end
 
 -- execute mission events, e == 1 is initial event, e == 99 is final event
@@ -436,11 +418,7 @@ function MissionEvent(e, onLoad)
     end
 
     -- call side effects for active events, check "eState[e] == 1" for multiple call events!
-    if(e == 98) then
-        rttr:GetPlayer(1):SetRestrictedArea()
-        rttr:GetPlayer(2):SetRestrictedArea()
-
-    elseif(e == 99) then
+    if(e == 99) then
         -- TODO: EnableNextMissions()
         -- Show opened arc - Done
         rttr:GetWorld():AddStaticObject(127, 48, 561, 0xFFFF, 2)

--- a/data/RTTR/campaigns/roman/MISS209.lua
+++ b/data/RTTR/campaigns/roman/MISS209.lua
@@ -30,7 +30,7 @@ function checkVersion()
 end
 -------------------------------- mission events and texts ---------------------
 -- Message-Window (mission statement and hints): 52 chars wide
-eIdx = {1, 2, 98, 99}
+eIdx = {1, 2, 99}
 
 rttr:RegisterTranslations(
 {
@@ -140,6 +140,9 @@ function onStart(isFirstStart)
         eHist = {["n"] = 0}
         MissionEvent(1)                         -- initial event / start screen
     end
+
+    rttr:GetWorld():SetComputerBarrier(10, 57, 73)
+    rttr:GetWorld():SetComputerBarrier(10, 39, 29)
 end
 
 function getAllowedChanges()
@@ -181,30 +184,6 @@ function addPlayerBld(p, onLoad)
     rttr:GetPlayer(p):DisableBuilding(BLD_HARBORBUILDING, false)
 
     if(p == 1) then
-        rttr:GetPlayer(p):SetRestrictedArea(
-            nil, nil,       -- enable the whole map
-                0,   0,
-                0, 127,
-                127, 127,
-                127,   0,
-            nil, nil,       -- R=10,    X=57,   Y=73    ->  R=10,   X=58,   Y=68    (Yellow HQ!)
-                 62,  76,
-                 67,  86,
-                 62,  96,
-                 52,  96,
-                 47,  86,
-                 52,  76,
-                 62,  76,
-            nil, nil,      -- northern pass
-                 39,  28,
-                 40,  28,
-                 40,  29,
-                 40,  30,
-                 39,  30,
-                 38,  29,
-                 39,  28,
-            nil, nil        -- ignore R=10, X=39,   Y=29
-        )
         if onLoad then return end
 
         rttr:GetPlayer(p):AIConstructionOrder(57, 73, BLD_FORTRESS)
@@ -444,10 +423,6 @@ function onOccupied(p, x, y)
 
     if( (x == 75) and (y == 40) ) then MissionEvent(99)
     end
-
-    if(not rttr:GetPlayer(1):IsInRestrictedArea(x, y)) then 
-        MissionEvent(98) -- for lifting restrictions
-    end
 end
 
 function onExplored(p, x, y, o)
@@ -464,11 +439,7 @@ function MissionEvent(e, onLoad)
     end
 
     -- call side effects for active events, check "eState[e] == 1" for multiple call events!
-    if(e == 98) then
-        rttr:GetPlayer(1):SetRestrictedArea()
-        rttr:GetPlayer(2):SetRestrictedArea()
-        
-    elseif(e == 99) then
+    if(e == 99) then
         -- TODO: EnableNextMissions()
         -- Show opened arc
         rttr:GetWorld():AddStaticObject(75, 40, 561, 0xFFFF, 2)

--- a/doc/lua/functions.md
+++ b/doc/lua/functions.md
@@ -379,6 +379,9 @@ rttr:GetWorld():AddAnimal(41, 44, SPEC_DUCK)
 
 [Back](#Lua-objects-and-their-methods)  
 
+**SetComputerBarrier(radius, x, y)**
+Defines an area with a specified (inclusive) radius around map point {x, y} in which the AI cannot build military buildings.
+
 ## Serializer
 
 The following methods are available.

--- a/libs/s25main/ai/aijh/AIResourceMap.cpp
+++ b/libs/s25main/ai/aijh/AIResourceMap.cpp
@@ -94,7 +94,9 @@ MapPoint AIResourceMap::findBestPosition(const MapPoint& pt, BuildingQuality siz
             // special case fish -> check for other fishery buildings
             if(res == AIResource::Fish && aii.isBuildingNearby(BuildingType::Fishery, curPt, 5))
                 continue;
-            if(res == AIResource::Borderland && aii.gwb.IsOnRoad(aii.gwb.GetNeighbour(curPt, Direction::SouthEast)))
+            if(res == AIResource::Borderland
+               && (aii.gwb.IsOnRoad(aii.gwb.GetNeighbour(curPt, Direction::SouthEast))
+                   || aii.gwb.IsInsideComputerBarrier(curPt)))
                 continue;
             // dont build next to empty harborspots
             if(aii.isHarborPosClose(curPt, 2, true))

--- a/libs/s25main/lua/LuaWorld.cpp
+++ b/libs/s25main/lua/LuaWorld.cpp
@@ -33,7 +33,8 @@ void LuaWorld::Register(kaguya::State& state)
     state["World"].setClass(kaguya::UserdataMetatable<LuaWorld>()
                               .addFunction("AddEnvObject", AddEnvObjectWrapper())
                               .addFunction("AddStaticObject", AddStaticObjectWrapper())
-                              .addFunction("AddAnimal", &LuaWorld::AddAnimal));
+                              .addFunction("AddAnimal", &LuaWorld::AddAnimal)
+                              .addFunction("SetComputerBarrier", &LuaWorld::SetComputerBarrier));
 }
 
 static bool isValidObject(unsigned file, unsigned id)
@@ -95,4 +96,9 @@ void LuaWorld::AddAnimal(int x, int y, lua::SafeEnum<Species> species)
 {
     MapPoint pos = gw.MakeMapPoint(Position(x, y));
     gw.AddFigure(pos, std::make_unique<noAnimal>(species, pos)).StartLiving();
+}
+
+void LuaWorld::SetComputerBarrier(unsigned radius, unsigned short x, unsigned short y)
+{
+    gw.SetComputerBarrier({x, y}, radius);
 }

--- a/libs/s25main/lua/LuaWorld.h
+++ b/libs/s25main/lua/LuaWorld.h
@@ -23,4 +23,5 @@ public:
     bool AddEnvObject(int x, int y, unsigned id, unsigned file = 0xFFFF);
     bool AddStaticObject(int x, int y, unsigned id, unsigned file = 0xFFFF, unsigned size = 1);
     void AddAnimal(int x, int y, lua::SafeEnum<Species> species);
+    void SetComputerBarrier(unsigned radius, unsigned short x, unsigned short y);
 };

--- a/libs/s25main/world/GameWorldBase.cpp
+++ b/libs/s25main/world/GameWorldBase.cpp
@@ -696,3 +696,14 @@ void GameWorldBase::RecalcBQ(const MapPoint pt)
         GetNotifications().publish(NodeNote(NodeNote::BQ, pt));
     }
 }
+
+void GameWorldBase::SetComputerBarrier(const MapPoint& pt, unsigned radius)
+{
+    for(const auto& pt : GetPointsInRadiusWithCenter(pt, radius))
+        ptsInsideComputerBarriers.insert(pt);
+}
+
+bool GameWorldBase::IsInsideComputerBarrier(const MapPoint& pt) const
+{
+    return ptsInsideComputerBarriers.count(pt);
+}

--- a/libs/s25main/world/GameWorldBase.h
+++ b/libs/s25main/world/GameWorldBase.h
@@ -13,6 +13,7 @@
 #include "postSystem/PostManager.h"
 #include "world/World.h"
 #include <memory>
+#include <set>
 #include <vector>
 
 class EventManager;
@@ -58,6 +59,7 @@ class GameWorldBase : public World
     const GlobalGameSettings& gameSettings;
     EventManager& em;
     std::unique_ptr<SoundManager> soundManager;
+    std::set<MapPoint, MapPointLess> ptsInsideComputerBarriers;
     LuaInterfaceGame* lua;
 
 protected:
@@ -208,6 +210,9 @@ public:
 
     /// Recalculates the BQ for the given point
     void RecalcBQ(MapPoint pt);
+
+    void SetComputerBarrier(const MapPoint& pt, unsigned radius);
+    bool IsInsideComputerBarrier(const MapPoint& pt) const;
 
     bool HasLua() const { return lua != nullptr; }
     LuaInterfaceGame& GetLua() const { return *lua; }

--- a/tests/s25Main/integration/testAI.cpp
+++ b/tests/s25Main/integration/testAI.cpp
@@ -20,6 +20,7 @@
 #include "nodeObjs/noTree.h"
 #include "gameTypes/GameTypesOutput.h"
 #include "gameData/BuildingProperties.h"
+#include "gameData/MilitaryConsts.h"
 #include "rttr/test/random.hpp"
 #include <boost/test/unit_test.hpp>
 #include <memory>
@@ -298,9 +299,9 @@ BOOST_FIXTURE_TEST_CASE(BuildWoodIndustry, WorldWithGCExecution<1>)
     BOOST_TEST(playerHasBld(player, BuildingType::Forester));
 }
 
-BOOST_FIXTURE_TEST_CASE(ExpandWhenNoSpace, BiggerWorldWithGCExecution)
+namespace {
+void forceExpansion(const GamePlayer& player, GameWorld& world)
 {
-    const GamePlayer& player = world.GetPlayer(curPlayer);
     // No space for saw mill due to altitude diff of 3 in range 2 -> Huts only
     for(unsigned y = 0; y < world.GetHeight(); y += 2)
     {
@@ -309,11 +310,14 @@ BOOST_FIXTURE_TEST_CASE(ExpandWhenNoSpace, BiggerWorldWithGCExecution)
     }
     RTTR_FOREACH_PT(MapPoint, world.GetSize())
     {
-        BOOST_TEST_REQUIRE(world.GetBQ(pt, curPlayer) <= BuildingQuality::Hut);
+        BOOST_TEST_REQUIRE(world.GetBQ(pt, player.GetPlayerId()) <= BuildingQuality::Hut);
     }
+}
+
+void runUntilMilitaryBuildingSiteFound(TestEventManager& em, unsigned curPlayer, GameWorld& world,
+                                       const std::list<noBuildingSite*>& bldSites)
+{
     auto ai = AIFactory::Create(AI::Info(AI::Type::Default, AI::Level::Hard), curPlayer, world);
-    const std::list<noBuildingSite*>& bldSites = player.GetBuildingRegister().GetBuildingSites();
-    // Can't build sawmill -> Expand anyway
     for(unsigned gf = 0; gf < 2000;)
     {
         std::vector<gc::GameCommandPtr> aiGcs = ai->FetchGameCommands();
@@ -329,8 +333,62 @@ BOOST_FIXTURE_TEST_CASE(ExpandWhenNoSpace, BiggerWorldWithGCExecution)
         if(containsBldType(bldSites, BuildingType::Barracks) || containsBldType(bldSites, BuildingType::Guardhouse))
             break;
     }
+}
+} // namespace
+
+BOOST_FIXTURE_TEST_CASE(ExpandWhenNoSpace, BiggerWorldWithGCExecution)
+{
+    const auto& player = world.GetPlayer(curPlayer);
+    const auto& bldSites = player.GetBuildingRegister().GetBuildingSites();
+
+    forceExpansion(player, world);
+    runUntilMilitaryBuildingSiteFound(em, curPlayer, world, bldSites);
+
     BOOST_TEST_REQUIRE(
       (containsBldType(bldSites, BuildingType::Barracks) || containsBldType(bldSites, BuildingType::Guardhouse)));
+}
+
+BOOST_FIXTURE_TEST_CASE(DoNotBuildMilitaryBuildingsWithinComputerBarrier, BiggerWorldWithGCExecution)
+{
+    const auto& player = world.GetPlayer(curPlayer);
+    const auto& bldSites = player.GetBuildingRegister().GetBuildingSites();
+
+    const auto& barrierPt = player.GetHQPos();
+    constexpr auto radius = HQ_RADIUS;
+
+    world.SetComputerBarrier(barrierPt, radius);
+    forceExpansion(player, world);
+    runUntilMilitaryBuildingSiteFound(em, curPlayer, world, bldSites);
+
+    BOOST_TEST_REQUIRE(
+      !(containsBldType(bldSites, BuildingType::Barracks) || containsBldType(bldSites, BuildingType::Guardhouse)));
+}
+
+BOOST_FIXTURE_TEST_CASE(DoBuildMilitaryBuildingsOutsideComputerBarrier, BiggerWorldWithGCExecution)
+{
+    const auto& player = world.GetPlayer(curPlayer);
+    const auto& bldSites = player.GetBuildingRegister().GetBuildingSites();
+
+    auto barrierPt = player.GetHQPos();
+    // move barrier 2 tiles west of HQ, now military buildings should be buildable to the east
+    barrierPt.x -= 2;
+    constexpr auto radius = HQ_RADIUS;
+
+    world.SetComputerBarrier(barrierPt, radius);
+    forceExpansion(player, world);
+    runUntilMilitaryBuildingSiteFound(em, curPlayer, world, bldSites);
+
+    BOOST_TEST_REQUIRE(
+      (containsBldType(bldSites, BuildingType::Barracks) || containsBldType(bldSites, BuildingType::Guardhouse)));
+
+    for(auto bldSite : bldSites)
+        BOOST_TEST_REQUIRE(!world.CheckPointsInRadius(
+          barrierPt, radius,
+          [bldSite](const MapPoint& pt, unsigned) {
+              const auto type = bldSite->GetBuildingType();
+              return (type == BuildingType::Barracks || type == BuildingType::Guardhouse) && pt == bldSite->GetPos();
+          },
+          true));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Adds `SetComputerBarrier` LUA function which works like `!GLOBAL_SET_COMPUTER_BARRIER` did in S2 RTX scripts. This makes it possible to script old campaigns much more simply than with the tools previously available.